### PR TITLE
feat: JWT認証以外の未実装機能を全て追加

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -9,6 +9,9 @@ import mbtiRouter from './routes/mbti';
 import thanksRouter from './routes/thanks';
 import notificationsRouter from './routes/notifications';
 import avatarRouter from './routes/avatar';
+import reviewsRouter from './routes/reviews';
+import moodForecastRouter from './routes/mood-forecast';
+import consultationRouter from './routes/consultation';
 import { errorHandler } from './middleware/errorHandler';
 
 const app = express();
@@ -24,6 +27,9 @@ app.use('/api', mbtiRouter);
 app.use('/api', thanksRouter);
 app.use('/api', notificationsRouter);
 app.use('/api', avatarRouter);
+app.use('/api', reviewsRouter);
+app.use('/api', moodForecastRouter);
+app.use('/api', consultationRouter);
 
 app.use(errorHandler);
 

--- a/backend/src/routes/consultation.ts
+++ b/backend/src/routes/consultation.ts
@@ -1,0 +1,30 @@
+import { Router, Request, Response, NextFunction } from 'express';
+import { createConsultation, listConsultations, archiveConsultation } from '../services/consultation.service';
+
+const router = Router();
+
+router.post('/consultation', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const { userId, title, content, selectedTheme } = req.body;
+    const consultation = await createConsultation({ userId, title, content, selectedTheme });
+    res.status(201).json(consultation);
+  } catch (e) { next(e); }
+});
+
+router.get('/users/:id/consultations', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const userId = parseInt(req.params.id, 10);
+    const consultations = await listConsultations(userId);
+    res.json(consultations);
+  } catch (e) { next(e); }
+});
+
+router.patch('/consultation/:id/archive', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const id = parseInt(req.params.id, 10);
+    const consultation = await archiveConsultation(id);
+    res.json(consultation);
+  } catch (e) { next(e); }
+});
+
+export default router;

--- a/backend/src/routes/mood-forecast.ts
+++ b/backend/src/routes/mood-forecast.ts
@@ -1,0 +1,22 @@
+import { Router, Request, Response, NextFunction } from 'express';
+import { getOrGenerateForecast, regenerateForecast } from '../services/mood-forecast.service';
+
+const router = Router();
+
+router.get('/users/:id/mood-forecast', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const userId = parseInt(req.params.id, 10);
+    const forecast = await getOrGenerateForecast(userId);
+    res.json(forecast);
+  } catch (e) { next(e); }
+});
+
+router.post('/users/:id/mood-forecast/regenerate', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const userId = parseInt(req.params.id, 10);
+    const forecast = await regenerateForecast(userId);
+    res.json(forecast);
+  } catch (e) { next(e); }
+});
+
+export default router;

--- a/backend/src/routes/reviews.ts
+++ b/backend/src/routes/reviews.ts
@@ -1,0 +1,22 @@
+import { Router, Request, Response, NextFunction } from 'express';
+import { generateMonthlyReview, listReviews } from '../services/review.service';
+
+const router = Router();
+
+router.post('/users/:id/reviews/generate', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const userId = parseInt(req.params.id, 10);
+    const review = await generateMonthlyReview(userId);
+    res.json(review);
+  } catch (e) { next(e); }
+});
+
+router.get('/users/:id/reviews', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const userId = parseInt(req.params.id, 10);
+    const reviews = await listReviews(userId);
+    res.json(reviews);
+  } catch (e) { next(e); }
+});
+
+export default router;

--- a/backend/src/services/consultation.service.ts
+++ b/backend/src/services/consultation.service.ts
@@ -1,0 +1,125 @@
+import { PrismaClient } from '@prisma/client';
+import { AppError, ConsultationResponse } from '../types';
+
+const prisma = new PrismaClient();
+
+type Theme = '悩み' | '不安' | '感情整理' | '自己理解' | 'その他';
+
+const GUIDANCE: Record<Theme, { type: string; steps: string[]; insight: string }> = {
+  '悩み': {
+    type: 'WORRY',
+    steps: [
+      '今、一番つらいと感じていることは何ですか？できるだけ具体的に言葉にしてみてください。',
+      'その悩みはいつ頃から続いていますか？きっかけになる出来事はありましたか？',
+      '自分を責めていることはありますか？あなたのせいではないことも、たくさんあります。',
+      'もし親友が同じ悩みを抱えていたら、あなたはどんな言葉をかけますか？',
+    ],
+    insight: '悩みを言葉にすることで、少し軽くなることがあります。あなたは一人ではありません。',
+  },
+  '不安': {
+    type: 'ANXIETY',
+    steps: [
+      '今、ここにある確かなものを3つ挙げてみてください（例：椅子、窓、自分の手）。',
+      '最悪の場合を想像してみました。その確率はどのくらいだと思いますか？',
+      '不安を感じている自分に「それはどんなメッセージですか？」と聞いてみてください。',
+      '一歩だけやるとしたら、どんな小さなことができますか？',
+    ],
+    insight: '不安は「備えよ」というサインです。小さな一歩が不安を和らげます。',
+  },
+  '感情整理': {
+    type: 'EMOTION',
+    steps: [
+      '今の気持ちに名前をつけるとしたら何でしょう？（例：悲しみ、もどかしさ、怒り）',
+      'その感情を体のどこで感じていますか？胸、お腹、頭…？',
+      'その感情に何かメッセージがあるとしたら、何を伝えたいでしょうか？',
+      'その感情を持っていてもいい、と自分に言ってあげてください。何か変わりましたか？',
+    ],
+    insight: '感情に名前をつけることで、感情に飲み込まれにくくなります。',
+  },
+  '自己理解': {
+    type: 'SELF',
+    steps: [
+      '最近うれしかった、または充実していたのはいつですか？それはどんな瞬間でしたか？',
+      '自分の強みだと思うことは何ですか？苦手な自分もあわせて教えてください。',
+      '1年後の自分に手紙を書くとしたら、どんな言葉をかけますか？',
+    ],
+    insight: '自己理解は比較ではなく、自分との対話から生まれます。',
+  },
+  'その他': {
+    type: 'OTHER',
+    steps: [
+      '今、頭の中にあることを自由に書き出してみてください。',
+      '今の自分に必要なのは「行動」「休息」「誰かに話す」のどれだと思いますか？',
+      '今日、自分を少し喜ばせることができるとしたら何をしますか？',
+    ],
+    insight: '自分の気持ちに気づいて、言葉にしようとしたこと、それだけで十分です。',
+  },
+};
+
+const AVATAR_REACTIONS: Record<string, string> = {
+  WORRY:   'あなたの悩みを受け止めました。ゆっくり一緒に考えていきましょう。',
+  ANXIETY: '不安な気持ち、伝わりました。深呼吸して、一歩ずつ進みましょう。',
+  EMOTION: '感情を整理しようとしているんですね。その勇気、素晴らしいです。',
+  SELF:    '自分と向き合おうとしているんですね。それはとても大切なことです。',
+  OTHER:   '今の気持ちを言葉にしてくれてありがとう。',
+};
+
+const toResponse = (c: {
+  id: number; userId: number; title: string | null; content: string;
+  selectedTheme: string | null; guidanceType: string | null; guidanceStepsJson: string;
+  insightSummary: string | null; avatarReaction: string | null;
+  isArchived: boolean; submittedAt: Date;
+}): ConsultationResponse => ({
+  id: c.id, userId: c.userId, title: c.title, content: c.content,
+  selectedTheme: c.selectedTheme, guidanceType: c.guidanceType,
+  guidanceStepsJson: c.guidanceStepsJson, insightSummary: c.insightSummary,
+  avatarReaction: c.avatarReaction, isArchived: c.isArchived, submittedAt: c.submittedAt,
+});
+
+export const createConsultation = async (data: {
+  userId: number;
+  content: string;
+  selectedTheme?: string;
+  title?: string;
+}): Promise<ConsultationResponse> => {
+  const user = await prisma.user.findUnique({ where: { id: data.userId } });
+  if (!user || user.isDeleted) throw new AppError(404, 'ユーザーが見つかりませんでした。');
+
+  const theme = (data.selectedTheme as Theme) ?? 'その他';
+  const guidance = GUIDANCE[theme] ?? GUIDANCE['その他'];
+
+  const consultation = await prisma.consultation.create({
+    data: {
+      userId: data.userId,
+      title: data.title ?? null,
+      content: data.content,
+      selectedTheme: theme,
+      guidanceType: guidance.type,
+      guidanceStepsJson: JSON.stringify(guidance.steps),
+      insightSummary: guidance.insight,
+      avatarReaction: AVATAR_REACTIONS[guidance.type] ?? null,
+      isArchived: false,
+    },
+  });
+
+  return toResponse(consultation);
+};
+
+export const listConsultations = async (userId: number): Promise<ConsultationResponse[]> => {
+  const user = await prisma.user.findUnique({ where: { id: userId } });
+  if (!user || user.isDeleted) throw new AppError(404, 'ユーザーが見つかりませんでした。');
+
+  const consultations = await prisma.consultation.findMany({
+    where: { userId, isArchived: false },
+    orderBy: { submittedAt: 'desc' },
+    take: 10,
+  });
+  return consultations.map(toResponse);
+};
+
+export const archiveConsultation = async (id: number): Promise<ConsultationResponse> => {
+  const c = await prisma.consultation.findUnique({ where: { id } });
+  if (!c) throw new AppError(404, '相談が見つかりませんでした。');
+  const updated = await prisma.consultation.update({ where: { id }, data: { isArchived: true } });
+  return toResponse(updated);
+};

--- a/backend/src/services/mood-forecast.service.ts
+++ b/backend/src/services/mood-forecast.service.ts
@@ -1,0 +1,142 @@
+import { PrismaClient } from '@prisma/client';
+import { AppError, MoodForecastResponse } from '../types';
+
+const prisma = new PrismaClient();
+
+const AVATAR_COMMENTS: Record<string, string> = {
+  SUNNY:     'この調子で行きましょう！あなたの光が周りを照らしています。',
+  RAINBOW:   '困難の後に虹が出ます。今、まさにその時期ですね。',
+  STAR:      '夜空の星のように、静かに輝いています。',
+  SPROUT:    '少しずつ、でも確実に前向きになっています。',
+  CLOUDY:    '雲の上には必ず青空があります。',
+  WHIRLWIND: '少しゆっくりしてみませんか？',
+  FOG:       '霧は必ず晴れます。今日は自分をいたわってあげてください。',
+  RAIN:      '雨の日は、自分に優しくする日です。',
+  SNOW:      '雪のような静かさの中に、美しさがあります。',
+  STORM:     'この嵐も、必ず過ぎ去ります。無理しないでください。',
+};
+
+const EMOTION_SUMMARIES: Record<string, string> = {
+  SUNNY:     'とても前向きな気持ちが続いています。',
+  RAINBOW:   '希望と癒しを感じる日が多かったようです。',
+  STAR:      '静かに深く思索する時間が多かったようです。',
+  SPROUT:    '小さな前向きさが積み重なっています。',
+  CLOUDY:    'ぼんやりとした静かな気持ちが続いています。',
+  WHIRLWIND: '焦りや忙しさを感じることが多かったようです。',
+  FOG:       '混乱や疲れを感じることが多かったようです。',
+  RAIN:      '悲しみや寂しさを感じることが多かったようです。',
+  SNOW:      '静かな孤独感を感じることが多かったようです。',
+  STORM:     '怒りや動揺を感じることが多かったようです。',
+};
+
+const toResponse = (f: {
+  id: number; userId: number; startDate: Date; endDate: Date;
+  mainMood: string; moodTrendJson: string; emotionSummary: string | null;
+  avatarComment: string | null; forecastedAt: Date;
+}): MoodForecastResponse => ({
+  id: f.id, userId: f.userId, startDate: f.startDate, endDate: f.endDate,
+  mainMood: f.mainMood, moodTrendJson: f.moodTrendJson,
+  emotionSummary: f.emotionSummary, avatarComment: f.avatarComment,
+  forecastedAt: f.forecastedAt,
+});
+
+export const getOrGenerateForecast = async (userId: number): Promise<MoodForecastResponse> => {
+  const user = await prisma.user.findUnique({ where: { id: userId } });
+  if (!user || user.isDeleted) throw new AppError(404, 'ユーザーが見つかりませんでした。');
+
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+
+  const existing = await prisma.moodForecast.findFirst({
+    where: { userId, forecastedAt: { gte: today } },
+    orderBy: { forecastedAt: 'desc' },
+  });
+  if (existing) return toResponse(existing);
+
+  const endDate = new Date();
+  const startDate = new Date();
+  startDate.setDate(startDate.getDate() - 30);
+
+  const posts = await prisma.post.findMany({
+    where: { userId, createdAt: { gte: startDate } },
+    orderBy: { createdAt: 'asc' },
+  });
+
+  if (posts.length === 0) throw new AppError(400, 'まだ投稿がありません。気持ちを記録してから確認してください。');
+
+  const moodCounts: Record<string, number> = {};
+  posts.forEach((p) => { moodCounts[p.mood] = (moodCounts[p.mood] ?? 0) + 1; });
+  const mainMood = Object.entries(moodCounts).sort((a, b) => b[1] - a[1])[0][0];
+
+  const recent7 = posts.slice(-7);
+  const moodTrend: Record<string, string> = {};
+  recent7.forEach((p) => {
+    const dateKey = p.createdAt.toISOString().split('T')[0];
+    moodTrend[dateKey] = p.mood;
+  });
+
+  const avgScore = Math.round(posts.reduce((s, p) => s + p.feelingScore, 0) / posts.length);
+  const emotionSummary =
+    `直近30日間（${posts.length}件）の平均スコアは${avgScore}点です。` +
+    (EMOTION_SUMMARIES[mainMood] ?? '');
+
+  const forecast = await prisma.moodForecast.create({
+    data: {
+      userId,
+      startDate,
+      endDate,
+      mainMood,
+      moodTrendJson: JSON.stringify(moodTrend),
+      emotionSummary,
+      avatarComment: AVATAR_COMMENTS[mainMood] ?? '',
+    },
+  });
+
+  return toResponse(forecast);
+};
+
+export const regenerateForecast = async (userId: number): Promise<MoodForecastResponse> => {
+  const user = await prisma.user.findUnique({ where: { id: userId } });
+  if (!user || user.isDeleted) throw new AppError(404, 'ユーザーが見つかりませんでした。');
+
+  const endDate = new Date();
+  const startDate = new Date();
+  startDate.setDate(startDate.getDate() - 30);
+
+  const posts = await prisma.post.findMany({
+    where: { userId, createdAt: { gte: startDate } },
+    orderBy: { createdAt: 'asc' },
+  });
+
+  if (posts.length === 0) throw new AppError(400, 'まだ投稿がありません。');
+
+  const moodCounts: Record<string, number> = {};
+  posts.forEach((p) => { moodCounts[p.mood] = (moodCounts[p.mood] ?? 0) + 1; });
+  const mainMood = Object.entries(moodCounts).sort((a, b) => b[1] - a[1])[0][0];
+
+  const recent7 = posts.slice(-7);
+  const moodTrend: Record<string, string> = {};
+  recent7.forEach((p) => {
+    const dateKey = p.createdAt.toISOString().split('T')[0];
+    moodTrend[dateKey] = p.mood;
+  });
+
+  const avgScore = Math.round(posts.reduce((s, p) => s + p.feelingScore, 0) / posts.length);
+  const emotionSummary =
+    `直近30日間（${posts.length}件）の平均スコアは${avgScore}点です。` +
+    (EMOTION_SUMMARIES[mainMood] ?? '');
+
+  const forecast = await prisma.moodForecast.create({
+    data: {
+      userId,
+      startDate,
+      endDate,
+      mainMood,
+      moodTrendJson: JSON.stringify(moodTrend),
+      emotionSummary,
+      avatarComment: AVATAR_COMMENTS[mainMood] ?? '',
+    },
+  });
+
+  return toResponse(forecast);
+};

--- a/backend/src/services/review.service.ts
+++ b/backend/src/services/review.service.ts
@@ -1,0 +1,95 @@
+import { PrismaClient } from '@prisma/client';
+import { AppError, ReviewResponse } from '../types';
+
+const prisma = new PrismaClient();
+
+const AVATAR_COMMENTS: Record<string, string> = {
+  SUNNY:     'とても輝かしい月でしたね。その笑顔、大切にしてください。',
+  RAINBOW:   '乗り越えた証が虹になりました。あなたは強いです。',
+  STAR:      '静かに深く考えた月でしたね。その思索はあなたの財産です。',
+  SPROUT:    '小さな芽吹きを積み重ねた月でした。着実に育っています。',
+  CLOUDY:    'ぼんやりした日も、それがあなたの正直な気持ちです。',
+  WHIRLWIND: '忙しく動き回った月でしたね。少し立ち止まって深呼吸を。',
+  FOG:       '霧の中でも前に進めた自分を認めてあげてください。',
+  RAIN:      '悲しみや寂しさを感じた月でした。それも大切な感情です。',
+  SNOW:      '静かな時間を過ごせましたか。自分をいたわれましたか？',
+  STORM:     '嵐のような月でしたね。それでも記録し続けたあなたはすごい。',
+};
+
+const toResponse = (r: {
+  id: number; userId: number; periodStart: Date; periodEnd: Date;
+  summaryText: string | null; selectedPostIdsJson: string;
+  highlightFeelingJson: string; avatarComment: string | null;
+  levelChange: number; reviewedAt: Date;
+}): ReviewResponse => ({
+  id: r.id, userId: r.userId, periodStart: r.periodStart, periodEnd: r.periodEnd,
+  summaryText: r.summaryText, selectedPostIdsJson: r.selectedPostIdsJson,
+  highlightFeelingJson: r.highlightFeelingJson, avatarComment: r.avatarComment,
+  levelChange: r.levelChange, reviewedAt: r.reviewedAt,
+});
+
+export const generateMonthlyReview = async (userId: number): Promise<ReviewResponse> => {
+  const user = await prisma.user.findUnique({ where: { id: userId } });
+  if (!user || user.isDeleted) throw new AppError(404, 'ユーザーが見つかりませんでした。');
+
+  const now = new Date();
+  const periodStart = new Date(now.getFullYear(), now.getMonth(), 1);
+  const periodEnd = new Date(now.getFullYear(), now.getMonth() + 1, 0, 23, 59, 59);
+
+  const posts = await prisma.post.findMany({
+    where: { userId, createdAt: { gte: periodStart, lte: periodEnd } },
+    orderBy: { createdAt: 'asc' },
+  });
+
+  if (posts.length === 0) throw new AppError(400, '今月の投稿がまだありません。');
+
+  const avgScore = Math.round(posts.reduce((s, p) => s + p.feelingScore, 0) / posts.length);
+
+  const moodCounts: Record<string, number> = {};
+  posts.forEach((p) => { moodCounts[p.mood] = (moodCounts[p.mood] ?? 0) + 1; });
+  const mainMood = Object.entries(moodCounts).sort((a, b) => b[1] - a[1])[0][0];
+
+  const sorted = [...posts].sort((a, b) => b.feelingScore - a.feelingScore);
+  const highlights = [sorted[0], sorted[sorted.length - 1]].filter(Boolean);
+
+  const summaryText =
+    `今月は${posts.length}回記録しました。平均スコアは${avgScore}点で、` +
+    `いちばん多かった天気は「${mainMood}」でした。`;
+
+  const avatarComment = AVATAR_COMMENTS[mainMood] ?? 'よく記録してくれました。';
+  const levelChange = posts.length >= 10 ? 1 : 0;
+
+  if (levelChange > 0) {
+    await prisma.user.update({ where: { id: userId }, data: { level: { increment: 1 } } });
+  }
+
+  const existing = await prisma.review.findFirst({
+    where: { userId, periodStart: { gte: periodStart } },
+  });
+
+  const data = {
+    summaryText,
+    selectedPostIdsJson: JSON.stringify(highlights.map((p) => p.id)),
+    highlightFeelingJson: JSON.stringify({ avg: avgScore, moodCounts }),
+    avatarComment,
+    levelChange,
+    reviewedAt: new Date(),
+  };
+
+  const review = existing
+    ? await prisma.review.update({ where: { id: existing.id }, data })
+    : await prisma.review.create({ data: { userId, periodStart, periodEnd, ...data } });
+
+  return toResponse(review);
+};
+
+export const listReviews = async (userId: number): Promise<ReviewResponse[]> => {
+  const user = await prisma.user.findUnique({ where: { id: userId } });
+  if (!user || user.isDeleted) throw new AppError(404, 'ユーザーが見つかりませんでした。');
+
+  const reviews = await prisma.review.findMany({
+    where: { userId },
+    orderBy: { periodStart: 'desc' },
+  });
+  return reviews.map(toResponse);
+};

--- a/backend/src/types/index.ts
+++ b/backend/src/types/index.ts
@@ -73,6 +73,45 @@ export interface AvatarResponse {
   updatedAt: Date;
 }
 
+export interface ReviewResponse {
+  id: number;
+  userId: number;
+  periodStart: Date;
+  periodEnd: Date;
+  summaryText: string | null;
+  selectedPostIdsJson: string;
+  highlightFeelingJson: string;
+  avatarComment: string | null;
+  levelChange: number;
+  reviewedAt: Date;
+}
+
+export interface MoodForecastResponse {
+  id: number;
+  userId: number;
+  startDate: Date;
+  endDate: Date;
+  mainMood: string;
+  moodTrendJson: string;
+  emotionSummary: string | null;
+  avatarComment: string | null;
+  forecastedAt: Date;
+}
+
+export interface ConsultationResponse {
+  id: number;
+  userId: number;
+  title: string | null;
+  content: string;
+  selectedTheme: string | null;
+  guidanceType: string | null;
+  guidanceStepsJson: string;
+  insightSummary: string | null;
+  avatarReaction: string | null;
+  isArchived: boolean;
+  submittedAt: Date;
+}
+
 export class AppError extends Error {
   constructor(
     public readonly statusCode: number,

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -6,6 +6,11 @@ import { RegisterPage } from './pages/RegisterPage';
 import { DashboardPage } from './pages/DashboardPage';
 import { CreatePostPage } from './pages/CreatePostPage';
 import { OnboardingPage } from './pages/OnboardingPage';
+import { NotificationsPage } from './pages/NotificationsPage';
+import { ProfilePage } from './pages/ProfilePage';
+import { MoodForecastPage } from './pages/MoodForecastPage';
+import { ReviewPage } from './pages/ReviewPage';
+import { ConsultationPage } from './pages/ConsultationPage';
 
 const App = () => (
   <AuthProvider>
@@ -17,6 +22,11 @@ const App = () => (
           <Route path="/register" element={<RegisterPage />} />
           <Route path="/posts/new" element={<CreatePostPage />} />
           <Route path="/onboarding" element={<OnboardingPage />} />
+          <Route path="/notifications" element={<NotificationsPage />} />
+          <Route path="/profile" element={<ProfilePage />} />
+          <Route path="/forecast" element={<MoodForecastPage />} />
+          <Route path="/reviews" element={<ReviewPage />} />
+          <Route path="/consultation" element={<ConsultationPage />} />
           <Route path="*" element={<Navigate to="/" replace />} />
         </Routes>
       </Layout>

--- a/frontend/src/api/consultation.ts
+++ b/frontend/src/api/consultation.ts
@@ -1,0 +1,16 @@
+import { request } from './client';
+import type { Consultation } from '../types';
+
+export const createConsultation = (data: {
+  userId: number;
+  content: string;
+  selectedTheme?: string;
+  title?: string;
+}): Promise<Consultation> =>
+  request<Consultation>('/consultation', { method: 'POST', body: JSON.stringify(data) });
+
+export const listConsultations = (userId: number): Promise<Consultation[]> =>
+  request<Consultation[]>(`/users/${userId}/consultations`);
+
+export const archiveConsultation = (id: number): Promise<Consultation> =>
+  request<Consultation>(`/consultation/${id}/archive`, { method: 'PATCH' });

--- a/frontend/src/api/moodForecast.ts
+++ b/frontend/src/api/moodForecast.ts
@@ -1,0 +1,8 @@
+import { request } from './client';
+import type { MoodForecast } from '../types';
+
+export const getMoodForecast = (userId: number): Promise<MoodForecast> =>
+  request<MoodForecast>(`/users/${userId}/mood-forecast`);
+
+export const regenerateForecast = (userId: number): Promise<MoodForecast> =>
+  request<MoodForecast>(`/users/${userId}/mood-forecast/regenerate`, { method: 'POST' });

--- a/frontend/src/api/notifications.ts
+++ b/frontend/src/api/notifications.ts
@@ -1,0 +1,8 @@
+import { request } from './client';
+import type { Notification } from '../types';
+
+export const listNotifications = (userId: number): Promise<Notification[]> =>
+  request<Notification[]>(`/users/${userId}/notifications`);
+
+export const markNotificationRead = (id: number): Promise<Notification> =>
+  request<Notification>(`/notifications/${id}/read`, { method: 'PATCH' });

--- a/frontend/src/api/reviews.ts
+++ b/frontend/src/api/reviews.ts
@@ -1,0 +1,8 @@
+import { request } from './client';
+import type { Review } from '../types';
+
+export const generateReview = (userId: number): Promise<Review> =>
+  request<Review>(`/users/${userId}/reviews/generate`, { method: 'POST' });
+
+export const listReviews = (userId: number): Promise<Review[]> =>
+  request<Review[]>(`/users/${userId}/reviews`);

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -1,10 +1,19 @@
-import { ReactNode } from 'react';
+import { ReactNode, useEffect, useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { useAuth } from '../context/AuthContext';
+import { listNotifications } from '../api/notifications';
 
 export const Layout = ({ children }: { children: ReactNode }) => {
   const { user, setUser } = useAuth();
   const navigate = useNavigate();
+  const [unreadCount, setUnreadCount] = useState(0);
+
+  useEffect(() => {
+    if (!user) return;
+    listNotifications(user.id)
+      .then((ns) => setUnreadCount(ns.filter((n) => !n.isRead).length))
+      .catch(() => { /* ignore */ });
+  }, [user]);
 
   const handleLogout = () => {
     setUser(null);
@@ -18,7 +27,16 @@ export const Layout = ({ children }: { children: ReactNode }) => {
         <nav style={styles.nav}>
           {user ? (
             <>
-              <span style={styles.userName}>{user.nickname ?? user.email.split('@')[0]}</span>
+              <Link to="/forecast" style={styles.navLink}>⛅ 天気予報</Link>
+              <Link to="/reviews" style={styles.navLink}>📖 ふり返り</Link>
+              <Link to="/consultation" style={styles.navLink}>🪞 こころの鏡</Link>
+              <Link to="/notifications" style={styles.navLink}>
+                🔔
+                {unreadCount > 0 && <span style={styles.badge}>{unreadCount}</span>}
+              </Link>
+              <Link to="/profile" style={styles.navLink}>
+                {user.nickname ?? user.email.split('@')[0]}
+              </Link>
               <button onClick={handleLogout} style={styles.logoutBtn}>ログアウト</button>
             </>
           ) : (
@@ -50,9 +68,20 @@ const styles: Record<string, React.CSSProperties> = {
     color: '#2d7a4f',
     textDecoration: 'none',
   },
-  nav: { display: 'flex', alignItems: 'center', gap: '1rem' },
-  navLink: { color: '#555', textDecoration: 'none', fontSize: '0.9rem' },
-  userName: { fontSize: '0.9rem', color: '#333' },
+  nav: { display: 'flex', alignItems: 'center', gap: '1rem', flexWrap: 'wrap' },
+  navLink: { color: '#555', textDecoration: 'none', fontSize: '0.9rem', position: 'relative' as const },
+  badge: {
+    position: 'absolute' as const,
+    top: '-6px',
+    right: '-8px',
+    background: '#ef4444',
+    color: '#fff',
+    fontSize: '0.65rem',
+    fontWeight: 700,
+    borderRadius: '10px',
+    padding: '1px 5px',
+    lineHeight: 1.2,
+  },
   logoutBtn: {
     background: 'none',
     border: '1px solid #ccc',

--- a/frontend/src/pages/ConsultationPage.tsx
+++ b/frontend/src/pages/ConsultationPage.tsx
@@ -1,0 +1,189 @@
+import { useEffect, useState } from 'react';
+import { useAuth } from '../context/AuthContext';
+import { useNavigate } from 'react-router-dom';
+import { createConsultation, listConsultations, archiveConsultation } from '../api/consultation';
+import type { Consultation } from '../types';
+
+const THEMES = [
+  { key: '悩み', label: '😔 悩み' },
+  { key: '不安', label: '😰 不安' },
+  { key: '感情整理', label: '💭 感情整理' },
+  { key: '自己理解', label: '🔍 自己理解' },
+  { key: 'その他', label: '✏️ その他' },
+];
+
+export const ConsultationPage = () => {
+  const { user } = useAuth();
+  const navigate = useNavigate();
+
+  const [theme, setTheme] = useState('');
+  const [content, setContent] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [submitError, setSubmitError] = useState('');
+  const [activeConsultation, setActiveConsultation] = useState<Consultation | null>(null);
+  const [stepIndex, setStepIndex] = useState(0);
+
+  const [consultations, setConsultations] = useState<Consultation[]>([]);
+  const [listLoading, setListLoading] = useState(true);
+
+  useEffect(() => {
+    if (!user) { navigate('/login'); return; }
+    listConsultations(user.id)
+      .then(setConsultations)
+      .catch(() => { /* ignore */ })
+      .finally(() => setListLoading(false));
+  }, [user, navigate]);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!user || !content.trim()) return;
+    setSubmitting(true);
+    setSubmitError('');
+    try {
+      const c = await createConsultation({ userId: user.id, content, selectedTheme: theme || undefined });
+      setActiveConsultation(c);
+      setStepIndex(0);
+      setConsultations((prev) => [c, ...prev]);
+      setContent('');
+    } catch (err: unknown) {
+      setSubmitError(err instanceof Error ? err.message : '送信に失敗しました。');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const handleArchive = async (id: number) => {
+    try {
+      await archiveConsultation(id);
+      setConsultations((prev) => prev.filter((c) => c.id !== id));
+      if (activeConsultation?.id === id) setActiveConsultation(null);
+    } catch { /* ignore */ }
+  };
+
+  const steps = activeConsultation ? JSON.parse(activeConsultation.guidanceStepsJson) as string[] : [];
+
+  return (
+    <div>
+      <h2 style={styles.heading}>🪞 こころの鏡</h2>
+
+      {!activeConsultation ? (
+        <form onSubmit={handleSubmit} style={styles.form}>
+          <p style={styles.desc}>今の気持ちをテーマを選んで話しかけてみてください。</p>
+
+          <div style={styles.themeRow}>
+            {THEMES.map((t) => (
+              <button
+                key={t.key}
+                type="button"
+                onClick={() => setTheme(t.key)}
+                style={{ ...styles.themeChip, ...(theme === t.key ? styles.themeChipActive : {}) }}
+              >
+                {t.label}
+              </button>
+            ))}
+          </div>
+
+          <textarea
+            style={styles.textarea}
+            rows={5}
+            placeholder="今の気持ちを自由に書いてください..."
+            value={content}
+            onChange={(e) => setContent(e.target.value)}
+            required
+          />
+
+          {submitError && <p style={styles.error}>{submitError}</p>}
+
+          <button type="submit" disabled={submitting} style={styles.submitBtn}>
+            {submitting ? '送信中...' : '💬 話しかける'}
+          </button>
+        </form>
+      ) : (
+        <div style={styles.guidanceBox}>
+          {activeConsultation.avatarReaction && (
+            <p style={styles.avatarReaction}>💬 {activeConsultation.avatarReaction}</p>
+          )}
+
+          <div style={styles.stepProgress}>
+            <span style={styles.stepLabel}>ステップ {stepIndex + 1} / {steps.length}</span>
+          </div>
+
+          <div style={styles.stepCard}>
+            <p style={styles.stepText}>{steps[stepIndex]}</p>
+          </div>
+
+          <div style={styles.stepActions}>
+            {stepIndex > 0 && (
+              <button onClick={() => setStepIndex((i) => i - 1)} style={styles.stepBtn}>← 前へ</button>
+            )}
+            {stepIndex < steps.length - 1 ? (
+              <button onClick={() => setStepIndex((i) => i + 1)} style={{ ...styles.stepBtn, ...styles.stepBtnPrimary }}>
+                次のステップ →
+              </button>
+            ) : (
+              <div style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem', flex: 1 }}>
+                {activeConsultation.insightSummary && (
+                  <p style={styles.insight}>✨ {activeConsultation.insightSummary}</p>
+                )}
+                <button onClick={() => setActiveConsultation(null)} style={{ ...styles.stepBtn, ...styles.stepBtnPrimary }}>
+                  新しい相談をする
+                </button>
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+
+      {!listLoading && consultations.length > 0 && (
+        <div style={styles.historySection}>
+          <h3 style={styles.historyTitle}>過去の相談</h3>
+          <div style={styles.historyList}>
+            {consultations.map((c) => (
+              <div key={c.id} style={styles.historyCard}>
+                <div style={styles.historyHeader}>
+                  {c.selectedTheme && <span style={styles.themeBadge}>{c.selectedTheme}</span>}
+                  <time style={styles.historyDate}>
+                    {new Date(c.submittedAt).toLocaleDateString('ja-JP', { month: 'short', day: 'numeric' })}
+                  </time>
+                  <button onClick={() => handleArchive(c.id)} style={styles.archiveBtn}>アーカイブ</button>
+                </div>
+                <p style={styles.historyContent}>{c.content.slice(0, 80)}{c.content.length > 80 ? '…' : ''}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+const styles: Record<string, React.CSSProperties> = {
+  heading: { marginBottom: '1.5rem', color: '#333' },
+  form: { background: '#fff', border: '1px solid #eee', borderRadius: '12px', padding: '1.5rem', marginBottom: '2rem', display: 'flex', flexDirection: 'column', gap: '1rem' },
+  desc: { margin: 0, color: '#666', fontSize: '0.9rem' },
+  themeRow: { display: 'flex', flexWrap: 'wrap', gap: '0.5rem' },
+  themeChip: { padding: '6px 14px', borderRadius: '20px', border: '1px solid #ddd', background: '#f9f9f9', cursor: 'pointer', fontSize: '0.88rem', color: '#555' },
+  themeChipActive: { background: '#2d7a4f', color: '#fff', borderColor: '#2d7a4f' },
+  textarea: { padding: '0.75rem', borderRadius: '8px', border: '1px solid #ddd', fontSize: '0.95rem', lineHeight: 1.6, resize: 'vertical', outline: 'none' },
+  error: { color: '#c00', fontSize: '0.88rem', margin: 0 },
+  submitBtn: { padding: '0.75rem', background: '#2d7a4f', color: '#fff', border: 'none', borderRadius: '10px', fontSize: '1rem', fontWeight: 600, cursor: 'pointer' },
+  guidanceBox: { background: '#fff', border: '1px solid #eee', borderRadius: '12px', padding: '1.5rem', marginBottom: '2rem' },
+  avatarReaction: { background: '#f0faf4', border: '1px solid #a7d4b8', borderRadius: '10px', padding: '0.75rem 1rem', color: '#2d7a4f', fontSize: '0.95rem', fontStyle: 'italic', marginBottom: '1rem' },
+  stepProgress: { marginBottom: '0.75rem' },
+  stepLabel: { fontSize: '0.82rem', color: '#999' },
+  stepCard: { background: '#f8f9fa', borderRadius: '10px', padding: '1.2rem', marginBottom: '1rem' },
+  stepText: { margin: 0, fontSize: '1rem', color: '#333', lineHeight: 1.7 },
+  stepActions: { display: 'flex', gap: '0.75rem', flexWrap: 'wrap' },
+  stepBtn: { padding: '0.6rem 1.2rem', border: '1px solid #ddd', borderRadius: '8px', background: '#f9f9f9', cursor: 'pointer', fontSize: '0.9rem', color: '#555' },
+  stepBtnPrimary: { background: '#2d7a4f', color: '#fff', border: 'none', fontWeight: 600 },
+  insight: { background: '#fef9c3', border: '1px solid #fde68a', borderRadius: '10px', padding: '0.75rem 1rem', color: '#78350f', fontSize: '0.9rem', margin: 0 },
+  historySection: { marginTop: '0.5rem' },
+  historyTitle: { fontSize: '1rem', color: '#555', marginBottom: '0.75rem' },
+  historyList: { display: 'flex', flexDirection: 'column', gap: '0.5rem' },
+  historyCard: { background: '#fff', border: '1px solid #eee', borderRadius: '10px', padding: '0.9rem 1rem' },
+  historyHeader: { display: 'flex', alignItems: 'center', gap: '0.5rem', marginBottom: '0.4rem' },
+  themeBadge: { fontSize: '0.8rem', background: '#e8f5e9', color: '#2d7a4f', padding: '2px 8px', borderRadius: '10px', fontWeight: 600 },
+  historyDate: { fontSize: '0.78rem', color: '#aaa' },
+  archiveBtn: { marginLeft: 'auto', background: 'none', border: '1px solid #ddd', borderRadius: '6px', padding: '2px 8px', fontSize: '0.78rem', color: '#888', cursor: 'pointer' },
+  historyContent: { margin: 0, fontSize: '0.88rem', color: '#555' },
+};

--- a/frontend/src/pages/MoodForecastPage.tsx
+++ b/frontend/src/pages/MoodForecastPage.tsx
@@ -1,0 +1,123 @@
+import { useEffect, useState } from 'react';
+import { useAuth } from '../context/AuthContext';
+import { useNavigate } from 'react-router-dom';
+import { getMoodForecast, regenerateForecast } from '../api/moodForecast';
+import type { MoodForecast } from '../types';
+
+const moodIcon: Record<string, string> = {
+  STORM: '⛈️', RAIN: '🌧️', SNOW: '❄️', FOG: '🌫️', CLOUDY: '⛅',
+  WHIRLWIND: '🌪️', SPROUT: '🌻', RAINBOW: '🌈', STAR: '🌟', SUNNY: '☀️',
+};
+const moodLabel: Record<string, string> = {
+  STORM: '嵐', RAIN: '雨', SNOW: '雪', FOG: '霧', CLOUDY: 'くもり',
+  WHIRLWIND: 'つむじ風', SPROUT: '芽吹き', RAINBOW: '虹', STAR: '星空', SUNNY: '晴れ',
+};
+
+export const MoodForecastPage = () => {
+  const { user } = useAuth();
+  const navigate = useNavigate();
+  const [forecast, setForecast] = useState<MoodForecast | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    if (!user) { navigate('/login'); return; }
+    getMoodForecast(user.id)
+      .then(setForecast)
+      .catch((e: Error) => setError(e.message))
+      .finally(() => setLoading(false));
+  }, [user, navigate]);
+
+  const handleRegenerate = async () => {
+    if (!user) return;
+    setRefreshing(true);
+    setError('');
+    try {
+      const f = await regenerateForecast(user.id);
+      setForecast(f);
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : '更新に失敗しました。');
+    } finally {
+      setRefreshing(false);
+    }
+  };
+
+  if (loading) return <p style={styles.center}>読み込み中...</p>;
+
+  if (error) return (
+    <div style={styles.errorBox}>
+      <p style={{ color: '#c00', marginBottom: '1rem' }}>{error}</p>
+      <p style={{ color: '#777', fontSize: '0.9rem' }}>気持ちを記録してからもう一度確認してください。</p>
+    </div>
+  );
+
+  if (!forecast) return null;
+
+  const moodTrend: Record<string, string> = JSON.parse(forecast.moodTrendJson);
+  const trendEntries = Object.entries(moodTrend).sort(([a], [b]) => a.localeCompare(b));
+
+  return (
+    <div>
+      <h2 style={styles.heading}>⛅ 気持ち天気予報</h2>
+
+      <div style={styles.mainCard}>
+        <div style={styles.bigIcon}>{moodIcon[forecast.mainMood] ?? '⛅'}</div>
+        <div style={styles.mainMoodLabel}>{moodLabel[forecast.mainMood] ?? forecast.mainMood}</div>
+        {forecast.avatarComment && (
+          <p style={styles.avatarComment}>💬 {forecast.avatarComment}</p>
+        )}
+      </div>
+
+      {trendEntries.length > 0 && (
+        <div style={styles.section}>
+          <h3 style={styles.sectionTitle}>直近7日間の天気</h3>
+          <div style={styles.trendRow}>
+            {trendEntries.map(([date, mood]) => (
+              <div key={date} style={styles.trendItem}>
+                <span style={styles.trendIcon}>{moodIcon[mood] ?? '⛅'}</span>
+                <span style={styles.trendDate}>
+                  {new Date(date).toLocaleDateString('ja-JP', { month: 'numeric', day: 'numeric' })}
+                </span>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {forecast.emotionSummary && (
+        <div style={styles.section}>
+          <h3 style={styles.sectionTitle}>感情サマリー</h3>
+          <p style={styles.summaryText}>{forecast.emotionSummary}</p>
+        </div>
+      )}
+
+      <button onClick={handleRegenerate} disabled={refreshing} style={styles.refreshBtn}>
+        {refreshing ? '更新中...' : '🔄 今すぐ更新する'}
+      </button>
+
+      <p style={styles.footerNote}>
+        最終更新: {new Date(forecast.forecastedAt).toLocaleDateString('ja-JP', { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' })}
+      </p>
+    </div>
+  );
+};
+
+const styles: Record<string, React.CSSProperties> = {
+  heading: { marginBottom: '1.5rem', color: '#333' },
+  center: { textAlign: 'center', marginTop: '3rem', color: '#666' },
+  errorBox: { textAlign: 'center', padding: '3rem 1rem', background: '#fff', borderRadius: '12px', border: '1px solid #eee' },
+  mainCard: { textAlign: 'center', background: '#fff', border: '1px solid #eee', borderRadius: '16px', padding: '2.5rem 1rem', marginBottom: '1.5rem' },
+  bigIcon: { fontSize: '4rem', lineHeight: 1 },
+  mainMoodLabel: { fontSize: '1.4rem', fontWeight: 700, color: '#333', marginTop: '0.5rem' },
+  avatarComment: { marginTop: '1rem', color: '#555', fontSize: '0.95rem', lineHeight: 1.6, fontStyle: 'italic' },
+  section: { background: '#fff', border: '1px solid #eee', borderRadius: '12px', padding: '1.2rem', marginBottom: '1rem' },
+  sectionTitle: { margin: '0 0 1rem', fontSize: '0.95rem', color: '#555', fontWeight: 600 },
+  trendRow: { display: 'flex', gap: '0.5rem', flexWrap: 'wrap' },
+  trendItem: { display: 'flex', flexDirection: 'column', alignItems: 'center', gap: '0.25rem', minWidth: '44px' },
+  trendIcon: { fontSize: '1.6rem' },
+  trendDate: { fontSize: '0.72rem', color: '#888' },
+  summaryText: { margin: 0, color: '#444', fontSize: '0.95rem', lineHeight: 1.7 },
+  refreshBtn: { display: 'block', width: '100%', padding: '0.8rem', background: '#2d7a4f', color: '#fff', border: 'none', borderRadius: '10px', fontSize: '1rem', fontWeight: 600, cursor: 'pointer', marginBottom: '0.75rem' },
+  footerNote: { textAlign: 'center', fontSize: '0.78rem', color: '#aaa' },
+};

--- a/frontend/src/pages/NotificationsPage.tsx
+++ b/frontend/src/pages/NotificationsPage.tsx
@@ -1,0 +1,85 @@
+import { useEffect, useState } from 'react';
+import { useAuth } from '../context/AuthContext';
+import { useNavigate } from 'react-router-dom';
+import { listNotifications, markNotificationRead } from '../api/notifications';
+import type { Notification } from '../types';
+
+const typeIcon: Record<string, string> = {
+  THANK: '💛',
+  REMINDER: '📅',
+  MOOD: '⛅',
+  ACHIEVEMENT: '✨',
+};
+
+export const NotificationsPage = () => {
+  const { user } = useAuth();
+  const navigate = useNavigate();
+  const [notifications, setNotifications] = useState<Notification[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    if (!user) { navigate('/login'); return; }
+    listNotifications(user.id)
+      .then(setNotifications)
+      .catch(() => setError('通知の取得に失敗しました。'))
+      .finally(() => setLoading(false));
+  }, [user, navigate]);
+
+  const handleClick = async (n: Notification) => {
+    if (n.isRead) return;
+    try {
+      const updated = await markNotificationRead(n.id);
+      setNotifications((prev) => prev.map((x) => (x.id === n.id ? updated : x)));
+    } catch { /* ignore */ }
+  };
+
+  if (loading) return <p style={styles.center}>読み込み中...</p>;
+  if (error) return <p style={{ ...styles.center, color: '#c00' }}>{error}</p>;
+
+  return (
+    <div>
+      <h2 style={styles.heading}>🔔 通知</h2>
+      {notifications.length === 0 ? (
+        <div style={styles.empty}>
+          <p>通知はまだありません。</p>
+          <p style={{ fontSize: '0.9rem', color: '#999' }}>ありがとうをもらったときなどに通知が届きます。</p>
+        </div>
+      ) : (
+        <ul style={styles.list}>
+          {notifications.map((n) => (
+            <li
+              key={n.id}
+              style={{ ...styles.item, background: n.isRead ? '#f9f9f9' : '#fffde7', cursor: n.isRead ? 'default' : 'pointer' }}
+              onClick={() => handleClick(n)}
+            >
+              <span style={styles.icon}>{typeIcon[n.type] ?? '🔔'}</span>
+              <div style={styles.body}>
+                <p style={styles.title}>{n.title}</p>
+                <p style={styles.message}>{n.message}</p>
+                <time style={styles.date}>
+                  {new Date(n.createdAt).toLocaleDateString('ja-JP', { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' })}
+                </time>
+              </div>
+              {!n.isRead && <span style={styles.badge}>未読</span>}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+};
+
+const styles: Record<string, React.CSSProperties> = {
+  heading: { marginBottom: '1.5rem', color: '#333' },
+  center: { textAlign: 'center', marginTop: '3rem', color: '#666' },
+  empty: { textAlign: 'center', padding: '3rem 1rem', color: '#777', background: '#fff', borderRadius: '12px', border: '1px solid #eee' },
+  list: { listStyle: 'none', padding: 0, margin: 0, display: 'flex', flexDirection: 'column', gap: '0.5rem' },
+  item: { display: 'flex', alignItems: 'flex-start', gap: '0.75rem', padding: '1rem', borderRadius: '10px', border: '1px solid #eee', transition: 'background 0.15s' },
+  icon: { fontSize: '1.4rem', flexShrink: 0 },
+  body: { flex: 1 },
+  title: { margin: '0 0 0.25rem', fontWeight: 600, fontSize: '0.95rem', color: '#333' },
+  message: { margin: '0 0 0.4rem', fontSize: '0.88rem', color: '#555' },
+  date: { fontSize: '0.78rem', color: '#999' },
+  badge: { flexShrink: 0, background: '#f59e0b', color: '#fff', fontSize: '0.72rem', fontWeight: 700, padding: '2px 8px', borderRadius: '10px' },
+};

--- a/frontend/src/pages/ProfilePage.tsx
+++ b/frontend/src/pages/ProfilePage.tsx
@@ -1,0 +1,101 @@
+import { useState } from 'react';
+import { useNavigate, Link } from 'react-router-dom';
+import { useAuth } from '../context/AuthContext';
+import { request } from '../api/client';
+import type { User } from '../types';
+
+export const ProfilePage = () => {
+  const { user, setUser } = useAuth();
+  const navigate = useNavigate();
+
+  if (!user) { navigate('/login'); return null; }
+
+  const [email, setEmail] = useState(user.email);
+  const [nickname, setNickname] = useState(user.nickname ?? '');
+  const [password, setPassword] = useState('');
+  const [saving, setSaving] = useState(false);
+  const [success, setSuccess] = useState('');
+  const [error, setError] = useState('');
+
+  const handleSave = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setSaving(true);
+    setError('');
+    setSuccess('');
+    try {
+      const body: Record<string, string> = { email, nickname };
+      if (password) body.password = password;
+      const updated = await request<User>(`/users/${user.id}`, {
+        method: 'PUT',
+        body: JSON.stringify(body),
+      });
+      setUser(updated);
+      setPassword('');
+      setSuccess('プロフィールを更新しました。');
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : '更新に失敗しました。');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const mbtiLabel = user.mbtiType
+    ? `${user.mbtiType}`
+    : '未診断';
+
+  return (
+    <div style={styles.wrap}>
+      <h2 style={styles.heading}>👤 プロフィール</h2>
+
+      <div style={styles.statsRow}>
+        <div style={styles.stat}><span style={styles.statNum}>Lv.{user.level}</span><span style={styles.statLabel}>レベル</span></div>
+        <div style={styles.stat}><span style={styles.statNum}>{user.kindnessTotal}</span><span style={styles.statLabel}>優しさ合計</span></div>
+        <div style={styles.stat}>
+          <span style={styles.statNum}>{mbtiLabel}</span>
+          <span style={styles.statLabel}>MBTIタイプ</span>
+        </div>
+      </div>
+
+      {user.mbtiType && (
+        <p style={styles.rediag}>
+          MBTIを再診断する → <Link to="/onboarding" style={styles.link}>診断ページへ</Link>
+        </p>
+      )}
+
+      <form onSubmit={handleSave} style={styles.form}>
+        <label style={styles.label}>メールアドレス</label>
+        <input style={styles.input} type="email" value={email} onChange={(e) => setEmail(e.target.value)} required />
+
+        <label style={styles.label}>ニックネーム</label>
+        <input style={styles.input} type="text" value={nickname} onChange={(e) => setNickname(e.target.value)} placeholder="任意" />
+
+        <label style={styles.label}>新しいパスワード（変更する場合のみ）</label>
+        <input style={styles.input} type="password" value={password} onChange={(e) => setPassword(e.target.value)} placeholder="8文字以上" minLength={8} />
+
+        {error && <p style={styles.error}>{error}</p>}
+        {success && <p style={styles.success}>{success}</p>}
+
+        <button type="submit" disabled={saving} style={styles.btn}>
+          {saving ? '保存中...' : '保存する'}
+        </button>
+      </form>
+    </div>
+  );
+};
+
+const styles: Record<string, React.CSSProperties> = {
+  wrap: { maxWidth: '480px', margin: '0 auto' },
+  heading: { marginBottom: '1.5rem', color: '#333' },
+  statsRow: { display: 'flex', gap: '1rem', marginBottom: '1.5rem' },
+  stat: { flex: 1, display: 'flex', flexDirection: 'column', alignItems: 'center', background: '#fff', border: '1px solid #eee', borderRadius: '12px', padding: '1rem 0.5rem' },
+  statNum: { fontSize: '1.4rem', fontWeight: 700, color: '#2d7a4f' },
+  statLabel: { fontSize: '0.78rem', color: '#777', marginTop: '0.25rem' },
+  rediag: { fontSize: '0.88rem', color: '#555', marginBottom: '1.5rem' },
+  link: { color: '#2d7a4f', fontWeight: 600 },
+  form: { background: '#fff', border: '1px solid #eee', borderRadius: '12px', padding: '1.5rem', display: 'flex', flexDirection: 'column', gap: '0.5rem' },
+  label: { fontSize: '0.88rem', color: '#555', fontWeight: 600 },
+  input: { padding: '0.6rem 0.8rem', borderRadius: '8px', border: '1px solid #ddd', fontSize: '0.95rem', outline: 'none' },
+  error: { color: '#c00', fontSize: '0.88rem', margin: 0 },
+  success: { color: '#2d7a4f', fontSize: '0.88rem', margin: 0 },
+  btn: { marginTop: '0.5rem', padding: '0.7rem', background: '#2d7a4f', color: '#fff', border: 'none', borderRadius: '8px', fontSize: '1rem', fontWeight: 600, cursor: 'pointer' },
+};

--- a/frontend/src/pages/ReviewPage.tsx
+++ b/frontend/src/pages/ReviewPage.tsx
@@ -1,0 +1,127 @@
+import { useEffect, useState } from 'react';
+import { useAuth } from '../context/AuthContext';
+import { useNavigate } from 'react-router-dom';
+import { generateReview, listReviews } from '../api/reviews';
+import type { Review } from '../types';
+
+const moodIcon: Record<string, string> = {
+  STORM: '⛈️', RAIN: '🌧️', SNOW: '❄️', FOG: '🌫️', CLOUDY: '⛅',
+  WHIRLWIND: '🌪️', SPROUT: '🌻', RAINBOW: '🌈', STAR: '🌟', SUNNY: '☀️',
+};
+
+export const ReviewPage = () => {
+  const { user } = useAuth();
+  const navigate = useNavigate();
+  const [reviews, setReviews] = useState<Review[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [generating, setGenerating] = useState(false);
+  const [error, setError] = useState('');
+  const [genError, setGenError] = useState('');
+
+  useEffect(() => {
+    if (!user) { navigate('/login'); return; }
+    listReviews(user.id)
+      .then(setReviews)
+      .catch(() => setError('ふり返りの取得に失敗しました。'))
+      .finally(() => setLoading(false));
+  }, [user, navigate]);
+
+  const handleGenerate = async () => {
+    if (!user) return;
+    setGenerating(true);
+    setGenError('');
+    try {
+      const review = await generateReview(user.id);
+      setReviews((prev) => {
+        const filtered = prev.filter((r) => r.id !== review.id);
+        return [review, ...filtered];
+      });
+    } catch (e: unknown) {
+      setGenError(e instanceof Error ? e.message : '生成に失敗しました。');
+    } finally {
+      setGenerating(false);
+    }
+  };
+
+  const highlight = (r: Review): { avg: number; moodCounts: Record<string, number> } | null => {
+    try { return JSON.parse(r.highlightFeelingJson); } catch { return null; }
+  };
+
+  const mainMood = (r: Review): string => {
+    const h = highlight(r);
+    if (!h) return '';
+    return Object.entries(h.moodCounts).sort((a, b) => b[1] - a[1])[0]?.[0] ?? '';
+  };
+
+  if (loading) return <p style={styles.center}>読み込み中...</p>;
+
+  return (
+    <div>
+      <h2 style={styles.heading}>📖 ふり返り</h2>
+
+      <div style={styles.generateBox}>
+        <p style={styles.generateDesc}>今月の記録をもとにふり返りを生成します。</p>
+        {genError && <p style={styles.error}>{genError}</p>}
+        <button onClick={handleGenerate} disabled={generating} style={styles.generateBtn}>
+          {generating ? '生成中...' : '✨ 今月のふり返りを生成'}
+        </button>
+      </div>
+
+      {error && <p style={{ color: '#c00', fontSize: '0.9rem' }}>{error}</p>}
+
+      {reviews.length === 0 ? (
+        <div style={styles.empty}>
+          <p>まだふり返りがありません。</p>
+          <p style={{ fontSize: '0.88rem', color: '#999' }}>上のボタンで今月のふり返りを作成できます。</p>
+        </div>
+      ) : (
+        <div style={styles.list}>
+          {reviews.map((r) => {
+            const mm = mainMood(r);
+            const h = highlight(r);
+            const period = `${new Date(r.periodStart).toLocaleDateString('ja-JP', { year: 'numeric', month: 'long' })}`;
+            return (
+              <div key={r.id} style={styles.card}>
+                <div style={styles.cardHeader}>
+                  <span style={styles.period}>{period}</span>
+                  {mm && <span style={styles.moodIcon}>{moodIcon[mm] ?? '⛅'}</span>}
+                  {r.levelChange > 0 && <span style={styles.levelBadge}>+{r.levelChange} Lv UP!</span>}
+                </div>
+                {r.summaryText && <p style={styles.summary}>{r.summaryText}</p>}
+                {h && (
+                  <p style={styles.score}>平均スコア: <strong>{h.avg}点</strong></p>
+                )}
+                {r.avatarComment && (
+                  <p style={styles.avatarComment}>💬 {r.avatarComment}</p>
+                )}
+                <time style={styles.reviewedAt}>
+                  生成日: {new Date(r.reviewedAt).toLocaleDateString('ja-JP', { month: 'short', day: 'numeric' })}
+                </time>
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+};
+
+const styles: Record<string, React.CSSProperties> = {
+  heading: { marginBottom: '1.5rem', color: '#333' },
+  center: { textAlign: 'center', marginTop: '3rem', color: '#666' },
+  generateBox: { background: '#fff', border: '1px solid #eee', borderRadius: '12px', padding: '1.5rem', marginBottom: '1.5rem', textAlign: 'center' },
+  generateDesc: { margin: '0 0 1rem', color: '#555', fontSize: '0.9rem' },
+  generateBtn: { padding: '0.75rem 2rem', background: '#2d7a4f', color: '#fff', border: 'none', borderRadius: '10px', fontSize: '1rem', fontWeight: 600, cursor: 'pointer' },
+  error: { color: '#c00', fontSize: '0.88rem', marginBottom: '0.75rem' },
+  empty: { textAlign: 'center', padding: '2.5rem 1rem', color: '#777', background: '#fff', borderRadius: '12px', border: '1px solid #eee' },
+  list: { display: 'flex', flexDirection: 'column', gap: '1rem' },
+  card: { background: '#fff', border: '1px solid #eee', borderRadius: '12px', padding: '1.2rem' },
+  cardHeader: { display: 'flex', alignItems: 'center', gap: '0.75rem', marginBottom: '0.75rem' },
+  period: { fontWeight: 700, fontSize: '1rem', color: '#333' },
+  moodIcon: { fontSize: '1.5rem' },
+  levelBadge: { marginLeft: 'auto', background: '#fef3c7', color: '#d97706', fontSize: '0.8rem', fontWeight: 700, padding: '2px 10px', borderRadius: '10px', border: '1px solid #fcd34d' },
+  summary: { margin: '0 0 0.5rem', color: '#444', fontSize: '0.95rem', lineHeight: 1.6 },
+  score: { margin: '0 0 0.5rem', fontSize: '0.9rem', color: '#555' },
+  avatarComment: { margin: '0 0 0.6rem', color: '#555', fontSize: '0.9rem', fontStyle: 'italic' },
+  reviewedAt: { fontSize: '0.78rem', color: '#aaa' },
+};

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -60,3 +60,42 @@ export interface Notification {
   relatedObjectId: number | null;
   createdAt: string;
 }
+
+export interface Review {
+  id: number;
+  userId: number;
+  periodStart: string;
+  periodEnd: string;
+  summaryText: string | null;
+  selectedPostIdsJson: string;
+  highlightFeelingJson: string;
+  avatarComment: string | null;
+  levelChange: number;
+  reviewedAt: string;
+}
+
+export interface MoodForecast {
+  id: number;
+  userId: number;
+  startDate: string;
+  endDate: string;
+  mainMood: string;
+  moodTrendJson: string;
+  emotionSummary: string | null;
+  avatarComment: string | null;
+  forecastedAt: string;
+}
+
+export interface Consultation {
+  id: number;
+  userId: number;
+  title: string | null;
+  content: string;
+  selectedTheme: string | null;
+  guidanceType: string | null;
+  guidanceStepsJson: string;
+  insightSummary: string | null;
+  avatarReaction: string | null;
+  isArchived: boolean;
+  submittedAt: string;
+}


### PR DESCRIPTION
## 概要

JWT認証を除いた未実装機能をすべて実装しました。

## 追加機能

### バックエンド

- **ふり返り（Review）**: 当月の投稿を集計してふり返りレコードを生成・一覧取得
- **気持ち天気予報（MoodForecast）**: 直近30日の投稿から天気予報を生成（当日キャッシュあり、強制再生成も可）
- **こころの鏡（Consultation）**: テーマ別（悩み/不安/感情整理/自己理解/その他）ガイダンスをテンプレートで生成、アーカイブ機能付き
- 上記3サービス用のルートを追加し `index.ts` に登録

### フロントエンド

| ページ | パス | 内容 |
|---|---|---|
| 通知 | `/notifications` | 通知一覧・タイプ別アイコン・クリックで既読 |
| プロフィール | `/profile` | email/nickname/パスワード編集、MBTI表示・再診断リンク |
| 気持ち天気予報 | `/forecast` | mainMood大アイコン・直近7日間天気・更新ボタン |
| ふり返り | `/reviews` | 今月のふり返り生成・過去ふり返り一覧 |
| こころの鏡 | `/consultation` | テーマchip選択→入力→ステップ式ガイダンス・過去相談一覧 |

- `Layout.tsx`: ナビに5ページへのリンクと未読通知バッジを追加
- `App.tsx`: 5つの新規ルートを追加
- 型定義（`Review`, `MoodForecast`, `Consultation`）とAPIクライアントを追加

## テスト方法

1. バックエンドを再起動（`npm run dev`）
2. 新規登録 → オンボーディング → ダッシュボード
3. 投稿を数件作成後、各ページを確認
   - `/forecast` — 気持ち天気予報が生成される
   - `/reviews` — ふり返り生成ボタンで当月サマリーが表示される
   - `/consultation` — テーマを選んで送信するとガイダンスが表示される
   - `/notifications` — ありがとうを送ると通知が届く
   - `/profile` — 情報編集・保存ができる

https://claude.ai/code/session_014VQsTEATddUxu472hyknsp

---
_Generated by [Claude Code](https://claude.ai/code/session_014VQsTEATddUxu472hyknsp)_