### PR TITLE
ありがとうシステム再設計: 投稿→コメント→ありがとう + 悪質コメント自動検出

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -17,10 +17,13 @@ model User {
   commentStyle      String?
   level             Int             @default(1)
   kindnessTotal     Int             @default(0)
+  penaltyCount      Int             @default(0)
+  isRestricted      Boolean         @default(false)
   reDiagnosisNeeded Boolean         @default(false)
   registeredAt      DateTime        @default(now())
   isDeleted         Boolean         @default(false)
   posts             Post[]
+  comments          Comment[]
   avatar            Avatar?
   diagnoses         MBTIDiagnosis[]
   attributeLogs     AttributeLog[]
@@ -44,9 +47,39 @@ model Post {
   isVisible       Boolean          @default(false)
   createdAt       DateTime         @default(now())
   analysis        FeelingAnalysis?
-  thanks          Thank[]
+  comments        Comment[]
 
   @@map("post")
+}
+
+model Comment {
+  id           Int      @id @default(autoincrement())
+  postId       Int
+  post         Post     @relation(fields: [postId], references: [id], onDelete: Cascade)
+  userId       Int
+  user         User     @relation(fields: [userId], references: [id])
+  text         String
+  isHidden     Boolean  @default(false)
+  hiddenReason String?
+  createdAt    DateTime @default(now())
+  thanks       Thank[]
+
+  @@map("comment")
+}
+
+model Thank {
+  id            Int      @id @default(autoincrement())
+  commentId     Int
+  comment       Comment  @relation(fields: [commentId], references: [id], onDelete: Cascade)
+  fromUserId    Int
+  fromUser      User     @relation("ThanksGiven", fields: [fromUserId], references: [id])
+  toUserId      Int
+  message       String?
+  kindnessScore Int      @default(3)
+  createdAt     DateTime @default(now())
+
+  @@unique([commentId, fromUserId])
+  @@map("thanks")
 }
 
 model FeelingAnalysis {
@@ -91,20 +124,6 @@ model MoodForecast {
   forecastedAt   DateTime @default(now())
 
   @@map("mood_forecast")
-}
-
-model Thank {
-  id            Int      @id @default(autoincrement())
-  postId        Int
-  post          Post     @relation(fields: [postId], references: [id], onDelete: Cascade)
-  fromUserId    Int
-  fromUser      User     @relation("ThanksGiven", fields: [fromUserId], references: [id])
-  toUserId      Int
-  message       String?
-  kindnessScore Int      @default(3)
-  createdAt     DateTime @default(now())
-
-  @@map("thanks")
 }
 
 model MBTIDiagnosis {

--- a/backend/prisma/seed.ts
+++ b/backend/prisma/seed.ts
@@ -150,6 +150,19 @@ const FORECAST_COMMENTS: Record<string, string> = {
   STORM: 'この嵐も、必ず過ぎ去ります。無理しないでください。',
 };
 
+const FORECAST_SUMMARIES: Record<string, string> = {
+  SUNNY: 'この頃は気持ちが明るく開けていたようです。そんな日が続いていること、すてきですね。',
+  RAINBOW: '困難の後に光を見つけた日が多かったようです。あなたの中に、回復する力があります。',
+  STAR: '静かに自分と向き合う時間が多かったようです。その深さは、あなたの大切な部分です。',
+  SPROUT: '少しずつ、でも着実に前向きな気持ちが芽吹いていたようです。',
+  CLOUDY: 'はっきりしないもやもやした日が多かったようです。それも、ありのままの自分です。',
+  WHIRLWIND: '心が揺れ動いた日が多かったようです。少しゆっくり休んでみませんか。',
+  FOG: '方向を見失いそうな日が続いていたようです。霧はいつか晴れます。',
+  RAIN: '涙のような気持ちの日が多かったようです。自分をいたわってあげてください。',
+  SNOW: '静けさの中で、静かに耐えていたようです。その優しさが、あなたらしさです。',
+  STORM: '激しい感情と向き合う日が続いていたようです。嵐の後には、必ず空が開けます。',
+};
+
 const REVIEW_COMMENTS: Record<string, string> = {
   SUNNY: 'とても輝かしい月でしたね。その笑顔、大切にしてください。',
   RAINBOW: '乗り越えた証が虹になりました。あなたは強いです。',
@@ -325,7 +338,6 @@ async function main() {
 
   for (const { user, defs } of allUserDefs) {
     const mainMood = computeMainMood(defs);
-    const avgScore = Math.round(defs.reduce((s, p) => s + p.score, 0) / defs.length);
     const moodTrend: Record<string, string> = {};
     defs.slice(0, 7).forEach((p) => {
       const key = daysAgo(p.days).toISOString().split('T')[0];
@@ -338,7 +350,7 @@ async function main() {
         endDate: today,
         mainMood,
         moodTrendJson: JSON.stringify(moodTrend),
-        emotionSummary: `直近30日間（${defs.length}件）の平均スコアは${avgScore}点です。`,
+        emotionSummary: FORECAST_SUMMARIES[mainMood] ?? '',
         avatarComment: FORECAST_COMMENTS[mainMood] ?? '',
       },
     });

--- a/backend/prisma/seed.ts
+++ b/backend/prisma/seed.ts
@@ -281,19 +281,23 @@ async function main() {
   console.log(`✅ Comments (${commentCount})`);
 
   // ── Thanks & Notifications ─────────────────────────────────────────────────
-  for (const sender of users) {
-    const targetComments = createdComments.filter((c) => c.userId !== sender.id).slice(0, 5);
-    for (const c of targetComments) {
+  // 投稿主のみ、自分の投稿についたコメントにありがとうを送れる仕様
+  for (const post of publicPosts) {
+    const postAuthor = users.find((u) => u.id === post.userId)!;
+    const commentsOnPost = createdComments.filter(
+      (c) => c.postId === post.id && c.userId !== post.userId,
+    );
+    for (const c of commentsOnPost) {
       const createdAt = daysAgo(Math.floor(Math.random() * 3) + 1);
       const thank = await prisma.thank.create({
-        data: { commentId: c.id, fromUserId: sender.id, toUserId: c.userId, kindnessScore: 3, createdAt },
+        data: { commentId: c.id, fromUserId: post.userId, toUserId: c.userId, kindnessScore: 3, createdAt },
       });
       await prisma.notification.create({
         data: {
           userId: c.userId,
           type: 'THANK',
           title: 'ありがとうが届きました',
-          message: `${sender.nickname} さんからありがとうをもらいました。`,
+          message: `${postAuthor.nickname} さんからありがとうをもらいました。`,
           relatedObjectId: thank.id,
           relatedObjectType: 'Thank',
           isRead: Math.random() > 0.5,

--- a/backend/prisma/seed.ts
+++ b/backend/prisma/seed.ts
@@ -175,6 +175,7 @@ async function main() {
   // Clear all data in dependency order
   await prisma.notification.deleteMany();
   await prisma.thank.deleteMany();
+  await prisma.comment.deleteMany();
   await prisma.feelingAnalysis.deleteMany();
   await prisma.consultation.deleteMany();
   await prisma.review.deleteMany();
@@ -229,21 +230,67 @@ async function main() {
   ]);
   console.log('✅ Avatars (5)');
 
-  // ── Thanks & Notifications ─────────────────────────────────────────────────
+  // ── Comments ───────────────────────────────────────────────────────────────
   const users = [haruka, taichi, miori, kento, aoi];
-  let thankCount = 0;
 
-  for (const sender of users) {
-    const targets = publicPosts.filter((p) => p.userId !== sender.id).slice(0, 4);
-    for (const target of targets) {
-      const createdAt = daysAgo(Math.floor(Math.random() * 5) + 1);
-      const thank = await prisma.thank.create({
-        data: { postId: target.id, fromUserId: sender.id, toUserId: target.userId, kindnessScore: 3, createdAt },
+  const commentTemplates = [
+    '気持ちを共有してくれてありがとうございます。一緒に乗り越えましょう！',
+    'その気持ち、よく分かります。無理せず自分のペースで。',
+    '読んでいて、すごく伝わってきました。ゆっくり休んでね。',
+    '素直に表現できるって、とても素晴らしいことだと思います。',
+    'いつも応援しています。あなたの感情は大切なものです。',
+    '今日も一歩一歩、着実に進んでいますね。',
+    '同じような気持ちになることあります。一人じゃないよ。',
+    'この投稿を見て、自分も勇気をもらいました。ありがとう。',
+    '感情を言葉にするって難しいのに、上手く伝わりました。',
+    '今日の気持ちを大切にしてね。明日はきっと違う風景が見えるはず。',
+    'あなたの正直な気持ちが、読んでいて心に刺さりました。',
+    '一緒に少しずつ前に進みましょう。応援しています！',
+  ];
+
+  let commentCount = 0;
+  let thankCount = 0;
+  const createdComments: Array<{ id: number; postId: number; userId: number }> = [];
+
+  for (const post of publicPosts) {
+    const commenters = users.filter((u) => u.id !== post.userId);
+    const numComments = Math.floor(Math.random() * 3) + 1;
+    for (let i = 0; i < numComments && i < commenters.length; i++) {
+      const commenter = commenters[i];
+      const template = commentTemplates[(commentCount) % commentTemplates.length];
+      const createdAt = daysAgo(Math.floor(Math.random() * 4) + 1);
+      const comment = await prisma.comment.create({
+        data: { postId: post.id, userId: commenter.id, text: template, isHidden: false, createdAt },
       });
-      const recipient = users.find((u) => u.id === target.userId)!;
+      createdComments.push({ id: comment.id, postId: post.id, userId: commenter.id });
       await prisma.notification.create({
         data: {
-          userId: target.userId,
+          userId: post.userId,
+          type: 'COMMENT',
+          title: 'コメントが届きました',
+          message: `${commenter.nickname} さんがコメントしました。`,
+          relatedObjectId: comment.id,
+          relatedObjectType: 'COMMENT',
+          isRead: Math.random() > 0.5,
+          createdAt,
+        },
+      });
+      commentCount++;
+    }
+  }
+  console.log(`✅ Comments (${commentCount})`);
+
+  // ── Thanks & Notifications ─────────────────────────────────────────────────
+  for (const sender of users) {
+    const targetComments = createdComments.filter((c) => c.userId !== sender.id).slice(0, 5);
+    for (const c of targetComments) {
+      const createdAt = daysAgo(Math.floor(Math.random() * 3) + 1);
+      const thank = await prisma.thank.create({
+        data: { commentId: c.id, fromUserId: sender.id, toUserId: c.userId, kindnessScore: 3, createdAt },
+      });
+      await prisma.notification.create({
+        data: {
+          userId: c.userId,
           type: 'THANK',
           title: 'ありがとうが届きました',
           message: `${sender.nickname} さんからありがとうをもらいました。`,
@@ -253,7 +300,7 @@ async function main() {
           createdAt,
         },
       });
-      await prisma.user.update({ where: { id: recipient.id }, data: { kindnessTotal: { increment: 3 } } });
+      await prisma.user.update({ where: { id: c.userId }, data: { kindnessTotal: { increment: 3 } } });
       thankCount++;
     }
   }

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -12,6 +12,7 @@ import avatarRouter from './routes/avatar';
 import reviewsRouter from './routes/reviews';
 import moodForecastRouter from './routes/mood-forecast';
 import consultationRouter from './routes/consultation';
+import commentsRouter from './routes/comments';
 import { errorHandler } from './middleware/errorHandler';
 
 const app = express();
@@ -30,6 +31,7 @@ app.use('/api', avatarRouter);
 app.use('/api', reviewsRouter);
 app.use('/api', moodForecastRouter);
 app.use('/api', consultationRouter);
+app.use('/api', commentsRouter);
 
 app.use(errorHandler);
 

--- a/backend/src/routes/comments.ts
+++ b/backend/src/routes/comments.ts
@@ -1,0 +1,31 @@
+import { Router, Request, Response, NextFunction } from 'express';
+import { z } from 'zod';
+import * as commentService from '../services/comment.service';
+
+const router = Router();
+
+const createSchema = z.object({
+  userId: z.number().int().positive(),
+  text: z.string().min(1, 'コメントを入力してください。').max(200, 'コメントは200文字以内で入力してください。'),
+});
+
+router.post('/posts/:id/comments', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const { userId, text } = createSchema.parse(req.body);
+    const comment = await commentService.createComment(Number(req.params.id), userId, text);
+    res.status(201).json(comment);
+  } catch (err) {
+    next(err);
+  }
+});
+
+router.get('/posts/:id/comments', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const comments = await commentService.listComments(Number(req.params.id));
+    res.json(comments);
+  } catch (err) {
+    next(err);
+  }
+});
+
+export default router;

--- a/backend/src/routes/thanks.ts
+++ b/backend/src/routes/thanks.ts
@@ -9,7 +9,7 @@ const createSchema = z.object({
   message: z.string().max(100).optional(),
 });
 
-router.post('/posts/:id/thank', async (req: Request, res: Response, next: NextFunction) => {
+router.post('/comments/:id/thank', async (req: Request, res: Response, next: NextFunction) => {
   try {
     const { fromUserId, message } = createSchema.parse(req.body);
     const thank = await thankService.createThank(Number(req.params.id), fromUserId, message);
@@ -19,7 +19,7 @@ router.post('/posts/:id/thank', async (req: Request, res: Response, next: NextFu
   }
 });
 
-router.get('/posts/:id/thanks', async (req: Request, res: Response, next: NextFunction) => {
+router.get('/comments/:id/thanks', async (req: Request, res: Response, next: NextFunction) => {
   try {
     const thanks = await thankService.listThanks(Number(req.params.id));
     res.json(thanks);

--- a/backend/src/routes/users.ts
+++ b/backend/src/routes/users.ts
@@ -1,6 +1,7 @@
 import { Router, Request, Response, NextFunction } from 'express';
 import { z } from 'zod';
 import * as userService from '../services/user.service';
+import * as avatarService from '../services/avatar.service';
 
 const router = Router();
 
@@ -24,6 +25,15 @@ router.get('/users/:id', async (req: Request, res: Response, next: NextFunction)
   try {
     const user = await userService.getUser(Number(req.params.id));
     res.json(user);
+  } catch (err) {
+    next(err);
+  }
+});
+
+router.get('/users/:id/avatar', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const avatar = await avatarService.getOrCreateAvatar(Number(req.params.id));
+    res.json(avatar);
   } catch (err) {
     next(err);
   }

--- a/backend/src/services/auth.service.ts
+++ b/backend/src/services/auth.service.ts
@@ -22,6 +22,8 @@ export const login = async (email: string, password: string): Promise<UserRespon
     mbtiType: user.mbtiType,
     level: user.level,
     kindnessTotal: user.kindnessTotal,
+    penaltyCount: user.penaltyCount,
+    isRestricted: user.isRestricted,
     registeredAt: user.registeredAt,
   };
 };

--- a/backend/src/services/auth.service.ts
+++ b/backend/src/services/auth.service.ts
@@ -24,6 +24,7 @@ export const login = async (email: string, password: string): Promise<UserRespon
     kindnessTotal: user.kindnessTotal,
     penaltyCount: user.penaltyCount,
     isRestricted: user.isRestricted,
+    reDiagnosisNeeded: user.reDiagnosisNeeded,
     registeredAt: user.registeredAt,
   };
 };

--- a/backend/src/services/comment.service.ts
+++ b/backend/src/services/comment.service.ts
@@ -18,12 +18,15 @@ const containsBlockedKeyword = (text: string): string | null => {
   return null;
 };
 
-const toResponse = (c: {
-  id: number; postId: number; userId: number;
-  user: { nickname: string | null };
-  text: string; isHidden: boolean; createdAt: Date;
-  _count: { thanks: number };
-}): CommentResponse => ({
+const toResponse = (
+  c: {
+    id: number; postId: number; userId: number;
+    user: { nickname: string | null };
+    text: string; isHidden: boolean; createdAt: Date;
+    _count: { thanks: number };
+  },
+  isThankedByAuthor = false,
+): CommentResponse => ({
   id: c.id,
   postId: c.postId,
   userId: c.userId,
@@ -32,6 +35,7 @@ const toResponse = (c: {
   isHidden: c.isHidden,
   createdAt: c.createdAt,
   thankCount: c._count.thanks,
+  isThankedByAuthor,
 });
 
 export const createComment = async (
@@ -90,7 +94,11 @@ export const listComments = async (postId: number): Promise<CommentResponse[]> =
   const comments = await prisma.comment.findMany({
     where: { postId, isHidden: false },
     orderBy: { createdAt: 'asc' },
-    include: { user: { select: { nickname: true } }, _count: { select: { thanks: true } } },
+    include: {
+      user: { select: { nickname: true } },
+      _count: { select: { thanks: true } },
+      thanks: { where: { fromUserId: post.userId }, select: { id: true } },
+    },
   });
-  return comments.map(toResponse);
+  return comments.map((c) => toResponse(c, c.thanks.length > 0));
 };

--- a/backend/src/services/comment.service.ts
+++ b/backend/src/services/comment.service.ts
@@ -1,0 +1,96 @@
+import { PrismaClient } from '@prisma/client';
+import { AppError, CommentResponse } from '../types';
+
+const prisma = new PrismaClient();
+
+const BLOCKED_KEYWORDS = [
+  '死ね', '氏ね', '死んで', '消えろ', '失せろ', '殺す', '殺せ',
+  'クソ野郎', 'バカ野郎', 'アホ野郎', 'キチガイ',
+  'ブス', 'デブ', 'ゴミ人間', '死ぬべき', '消えて', 'うせろ',
+  'いらない', '最低最悪', 'キモい', 'きもい',
+  '自殺しろ', 'うざい死ね', '消えてしまえ',
+];
+
+const containsBlockedKeyword = (text: string): string | null => {
+  for (const kw of BLOCKED_KEYWORDS) {
+    if (text.includes(kw)) return kw;
+  }
+  return null;
+};
+
+const toResponse = (c: {
+  id: number; postId: number; userId: number;
+  user: { nickname: string | null };
+  text: string; isHidden: boolean; createdAt: Date;
+  _count: { thanks: number };
+}): CommentResponse => ({
+  id: c.id,
+  postId: c.postId,
+  userId: c.userId,
+  authorNickname: c.user.nickname,
+  text: c.text,
+  isHidden: c.isHidden,
+  createdAt: c.createdAt,
+  thankCount: c._count.thanks,
+});
+
+export const createComment = async (
+  postId: number,
+  userId: number,
+  text: string,
+): Promise<CommentResponse> => {
+  const user = await prisma.user.findUnique({ where: { id: userId } });
+  if (!user || user.isDeleted) throw new AppError(404, 'ユーザーが見つかりませんでした。');
+  if (user.isRestricted) throw new AppError(403, 'コメントの投稿が制限されています。');
+
+  const post = await prisma.post.findUnique({ where: { id: postId } });
+  if (!post) throw new AppError(404, '投稿が見つかりませんでした。');
+
+  const hitKeyword = containsBlockedKeyword(text);
+  const isHidden = hitKeyword !== null;
+
+  const comment = await prisma.comment.create({
+    data: {
+      postId,
+      userId,
+      text,
+      isHidden,
+      hiddenReason: isHidden ? '自動検出による非表示' : null,
+    },
+    include: { user: { select: { nickname: true } }, _count: { select: { thanks: true } } },
+  });
+
+  if (isHidden) {
+    const updated = await prisma.user.update({
+      where: { id: userId },
+      data: { penaltyCount: { increment: 1 } },
+    });
+    if (updated.penaltyCount >= 3 && !updated.isRestricted) {
+      await prisma.user.update({ where: { id: userId }, data: { isRestricted: true } });
+    }
+    await prisma.notification.create({
+      data: {
+        userId,
+        type: 'PENALTY',
+        title: 'コメントが非表示になりました',
+        message: `投稿したコメントが不適切なコンテンツとして検出され、非表示になりました。${updated.penaltyCount >= 3 ? '繰り返しの違反によりコメントが制限されました。' : `あと${3 - updated.penaltyCount}回の違反でコメントが制限されます。`}`,
+        relatedObjectId: comment.id,
+        relatedObjectType: 'Comment',
+      },
+    });
+  }
+
+  return toResponse(comment);
+};
+
+export const listComments = async (postId: number): Promise<CommentResponse[]> => {
+  const post = await prisma.post.findUnique({ where: { id: postId } });
+  if (!post) throw new AppError(404, '投稿が見つかりませんでした。');
+
+  const comments = await prisma.comment.findMany({
+    where: { postId, isHidden: false },
+    orderBy: { createdAt: 'asc' },
+    include: { user: { select: { nickname: true } }, _count: { select: { thanks: true } } },
+  });
+  return comments.map(toResponse);
+};

--- a/backend/src/services/mbti.service.ts
+++ b/backend/src/services/mbti.service.ts
@@ -25,7 +25,7 @@ export const createInitialDiagnosis = async (
 
   await prisma.user.update({
     where: { id: userId },
-    data: { mbtiType: typeCode },
+    data: { mbtiType: typeCode, reDiagnosisNeeded: false },
   });
 
   await prisma.avatar.upsert({

--- a/backend/src/services/mood-forecast.service.ts
+++ b/backend/src/services/mood-forecast.service.ts
@@ -17,16 +17,16 @@ const AVATAR_COMMENTS: Record<string, string> = {
 };
 
 const EMOTION_SUMMARIES: Record<string, string> = {
-  SUNNY:     'とても前向きな気持ちが続いています。',
-  RAINBOW:   '希望と癒しを感じる日が多かったようです。',
-  STAR:      '静かに深く思索する時間が多かったようです。',
-  SPROUT:    '小さな前向きさが積み重なっています。',
-  CLOUDY:    'ぼんやりとした静かな気持ちが続いています。',
-  WHIRLWIND: '焦りや忙しさを感じることが多かったようです。',
-  FOG:       '混乱や疲れを感じることが多かったようです。',
-  RAIN:      '悲しみや寂しさを感じることが多かったようです。',
-  SNOW:      '静かな孤独感を感じることが多かったようです。',
-  STORM:     '怒りや動揺を感じることが多かったようです。',
+  SUNNY:     'この頃は気持ちが明るく開けていたようです。そんな日が続いていること、すてきですね。',
+  RAINBOW:   '困難の後に光を見つけた日が多かったようです。あなたの中に、回復する力があります。',
+  STAR:      '静かに自分と向き合う時間が多かったようです。その深さは、あなたの大切な部分です。',
+  SPROUT:    '少しずつ、でも着実に前向きな気持ちが芽吹いていたようです。',
+  CLOUDY:    'はっきりしないもやもやした日が多かったようです。それも、ありのままの自分です。',
+  WHIRLWIND: '心が揺れ動いた日が多かったようです。少しゆっくり休んでみませんか。',
+  FOG:       '方向を見失いそうな日が続いていたようです。霧はいつか晴れます。',
+  RAIN:      '涙のような気持ちの日が多かったようです。自分をいたわってあげてください。',
+  SNOW:      '静けさの中で、静かに耐えていたようです。その優しさが、あなたらしさです。',
+  STORM:     '激しい感情と向き合う日が続いていたようです。嵐の後には、必ず空が開けます。',
 };
 
 const toResponse = (f: {
@@ -75,10 +75,7 @@ export const getOrGenerateForecast = async (userId: number): Promise<MoodForecas
     moodTrend[dateKey] = p.mood;
   });
 
-  const avgScore = Math.round(posts.reduce((s, p) => s + p.feelingScore, 0) / posts.length);
-  const emotionSummary =
-    `直近30日間（${posts.length}件）の平均スコアは${avgScore}点です。` +
-    (EMOTION_SUMMARIES[mainMood] ?? '');
+  const emotionSummary = EMOTION_SUMMARIES[mainMood] ?? '';
 
   const forecast = await prisma.moodForecast.create({
     data: {
@@ -121,10 +118,7 @@ export const regenerateForecast = async (userId: number): Promise<MoodForecastRe
     moodTrend[dateKey] = p.mood;
   });
 
-  const avgScore = Math.round(posts.reduce((s, p) => s + p.feelingScore, 0) / posts.length);
-  const emotionSummary =
-    `直近30日間（${posts.length}件）の平均スコアは${avgScore}点です。` +
-    (EMOTION_SUMMARIES[mainMood] ?? '');
+  const emotionSummary = EMOTION_SUMMARIES[mainMood] ?? '';
 
   const forecast = await prisma.moodForecast.create({
     data: {

--- a/backend/src/services/post.service.ts
+++ b/backend/src/services/post.service.ts
@@ -33,6 +33,31 @@ const requireUser = async (userId: number): Promise<void> => {
   if (!user || user.isDeleted) throw new AppError(404, 'ユーザーが見つかりませんでした。');
 };
 
+const INTROVERT_MOODS = ['STAR', 'FOG', 'SNOW', 'RAIN', 'CLOUDY'];
+const EXTROVERT_MOODS = ['SUNNY', 'RAINBOW', 'STORM', 'WHIRLWIND'];
+
+const checkAndUpdateReDiagnosis = async (userId: number): Promise<void> => {
+  const user = await prisma.user.findUnique({ where: { id: userId } });
+  if (!user?.mbtiType) return;
+
+  const recentPosts = await prisma.post.findMany({
+    where: { userId },
+    orderBy: { createdAt: 'desc' },
+    take: 10,
+    select: { mood: true },
+  });
+  if (recentPosts.length < 5) return;
+
+  const introCount = recentPosts.filter((p) => INTROVERT_MOODS.includes(p.mood)).length;
+  const extroCount = recentPosts.filter((p) => EXTROVERT_MOODS.includes(p.mood)).length;
+  const isExtrovert = user.mbtiType.startsWith('E');
+  const threshold = Math.ceil(recentPosts.length * 0.7);
+
+  if ((isExtrovert && introCount >= threshold) || (!isExtrovert && extroCount >= threshold)) {
+    await prisma.user.update({ where: { id: userId }, data: { reDiagnosisNeeded: true } });
+  }
+};
+
 const buildEmotionVector = (feelingScore: number): string => {
   const normalized = feelingScore / 100;
   const joy = Math.max(0, normalized - 0.3);
@@ -94,6 +119,8 @@ export const createPost = async (data: {
     create: { userId: data.userId, mood, fixedType: null },
     update: { mood, updatedAt: new Date() },
   });
+
+  await checkAndUpdateReDiagnosis(data.userId);
 
   return toResponse(post);
 };

--- a/backend/src/services/post.service.ts
+++ b/backend/src/services/post.service.ts
@@ -4,6 +4,19 @@ import { resolveMood } from '../utils/mood';
 
 const prisma = new PrismaClient();
 
+const MOOD_TO_EXPRESSION: Record<string, string> = {
+  STORM:     'ANGRY',
+  RAIN:      'SAD',
+  SNOW:      'SAD',
+  FOG:       'ANXIOUS',
+  CLOUDY:    'NEUTRAL',
+  WHIRLWIND: 'ANXIOUS',
+  SPROUT:    'HOPEFUL',
+  RAINBOW:   'HAPPY',
+  STAR:      'DREAMY',
+  SUNNY:     'CHEERFUL',
+};
+
 const parseKeywords = (raw: string): string[] => {
   try { return JSON.parse(raw) as string[]; } catch { return []; }
 };
@@ -114,10 +127,11 @@ export const createPost = async (data: {
     },
   });
 
+  const expression = MOOD_TO_EXPRESSION[mood] ?? 'NEUTRAL';
   await prisma.avatar.upsert({
     where: { userId: data.userId },
-    create: { userId: data.userId, mood, fixedType: null },
-    update: { mood, updatedAt: new Date() },
+    create: { userId: data.userId, mood, expression, fixedType: null },
+    update: { mood, expression, updatedAt: new Date() },
   });
 
   await checkAndUpdateReDiagnosis(data.userId);

--- a/backend/src/services/thank.service.ts
+++ b/backend/src/services/thank.service.ts
@@ -41,6 +41,11 @@ export const createThank = async (
   const already = await prisma.thank.findUnique({ where: { commentId_fromUserId: { commentId, fromUserId } } });
   if (already) throw new AppError(409, 'すでにありがとうを送っています。');
 
+  const thanksOnPostCount = await prisma.thank.count({
+    where: { fromUserId, comment: { postId: comment.postId } },
+  });
+  if (thanksOnPostCount >= 5) throw new AppError(400, '1つの投稿に対してありがとうは最大5件までです。');
+
   const sender = await prisma.user.findUnique({ where: { id: fromUserId } });
 
   const thank = await prisma.thank.create({

--- a/backend/src/services/thank.service.ts
+++ b/backend/src/services/thank.service.ts
@@ -5,7 +5,7 @@ const prisma = new PrismaClient();
 
 const toResponse = (thank: {
   id: number;
-  postId: number;
+  commentId: number;
   fromUserId: number;
   toUserId: number;
   message: string | null;
@@ -13,7 +13,7 @@ const toResponse = (thank: {
   createdAt: Date;
 }): ThankResponse => ({
   id: thank.id,
-  postId: thank.postId,
+  commentId: thank.commentId,
   fromUserId: thank.fromUserId,
   toUserId: thank.toUserId,
   message: thank.message,
@@ -22,59 +22,62 @@ const toResponse = (thank: {
 });
 
 export const createThank = async (
-  postId: number,
+  commentId: number,
   fromUserId: number,
   message?: string,
 ): Promise<ThankResponse> => {
-  const post = await prisma.post.findUnique({ where: { id: postId } });
-  if (!post) throw new AppError(404, '投稿が見つかりませんでした。');
+  const comment = await prisma.comment.findUnique({
+    where: { id: commentId },
+    include: { user: { select: { nickname: true } } },
+  });
+  if (!comment) throw new AppError(404, 'コメントが見つかりませんでした。');
+  if (comment.isHidden) throw new AppError(400, 'このコメントにはありがとうを送れません。');
+  if (comment.userId === fromUserId) throw new AppError(400, '自分のコメントにはありがとうできません。');
 
-  if (post.userId === fromUserId) {
-    throw new AppError(400, '自分の投稿にありがとうはできません。');
-  }
-
-  const already = await prisma.thank.findFirst({ where: { postId, fromUserId } });
+  const already = await prisma.thank.findUnique({ where: { commentId_fromUserId: { commentId, fromUserId } } });
   if (already) throw new AppError(409, 'すでにありがとうを送っています。');
+
+  const sender = await prisma.user.findUnique({ where: { id: fromUserId } });
 
   const thank = await prisma.thank.create({
     data: {
-      postId,
+      commentId,
       fromUserId,
-      toUserId: post.userId,
+      toUserId: comment.userId,
       message: message ?? null,
       kindnessScore: 3,
     },
   });
 
   await prisma.user.update({
-    where: { id: post.userId },
+    where: { id: comment.userId },
     data: { kindnessTotal: { increment: 1 } },
   });
 
   await prisma.notification.create({
     data: {
-      userId: post.userId,
-      type: 'THANK_RECEIVED',
+      userId: comment.userId,
+      type: 'THANK',
       title: 'ありがとうが届きました',
       message: message
-        ? `「${message}」というメッセージが届きました。`
-        : 'あなたの投稿にありがとうが届きました。',
-      relatedObjectId: postId,
-      relatedObjectType: 'POST',
+        ? `${sender?.nickname ?? 'だれか'} さんから「${message}」というメッセージが届きました。`
+        : `${sender?.nickname ?? 'だれか'} さんからありがとうをもらいました。`,
+      relatedObjectId: thank.id,
+      relatedObjectType: 'Thank',
     },
   });
 
   return toResponse(thank);
 };
 
-export const listThanks = async (postId: number): Promise<ThankResponse[]> => {
-  const post = await prisma.post.findUnique({ where: { id: postId } });
-  if (!post) throw new AppError(404, '投稿が見つかりませんでした。');
+export const listThanks = async (commentId: number): Promise<ThankResponse[]> => {
+  const comment = await prisma.comment.findUnique({ where: { id: commentId } });
+  if (!comment) throw new AppError(404, 'コメントが見つかりませんでした。');
 
   const thanks = await prisma.thank.findMany({
-    where: { postId },
+    where: { commentId },
     orderBy: { createdAt: 'desc' },
-    take: 5,
+    take: 10,
   });
   return thanks.map(toResponse);
 };

--- a/backend/src/services/thank.service.ts
+++ b/backend/src/services/thank.service.ts
@@ -28,10 +28,14 @@ export const createThank = async (
 ): Promise<ThankResponse> => {
   const comment = await prisma.comment.findUnique({
     where: { id: commentId },
-    include: { user: { select: { nickname: true } } },
+    include: {
+      user: { select: { nickname: true } },
+      post: { select: { userId: true } },
+    },
   });
   if (!comment) throw new AppError(404, 'コメントが見つかりませんでした。');
   if (comment.isHidden) throw new AppError(400, 'このコメントにはありがとうを送れません。');
+  if (comment.post.userId !== fromUserId) throw new AppError(403, '投稿主のみありがとうを送れます。');
   if (comment.userId === fromUserId) throw new AppError(400, '自分のコメントにはありがとうできません。');
 
   const already = await prisma.thank.findUnique({ where: { commentId_fromUserId: { commentId, fromUserId } } });

--- a/backend/src/services/user.service.ts
+++ b/backend/src/services/user.service.ts
@@ -13,6 +13,7 @@ const toResponse = (user: {
   kindnessTotal: number;
   penaltyCount: number;
   isRestricted: boolean;
+  reDiagnosisNeeded: boolean;
   registeredAt: Date;
 }): UserResponse => ({
   id: user.id,
@@ -23,6 +24,7 @@ const toResponse = (user: {
   kindnessTotal: user.kindnessTotal,
   penaltyCount: user.penaltyCount,
   isRestricted: user.isRestricted,
+  reDiagnosisNeeded: user.reDiagnosisNeeded,
   registeredAt: user.registeredAt,
 });
 

--- a/backend/src/services/user.service.ts
+++ b/backend/src/services/user.service.ts
@@ -11,6 +11,8 @@ const toResponse = (user: {
   mbtiType: string | null;
   level: number;
   kindnessTotal: number;
+  penaltyCount: number;
+  isRestricted: boolean;
   registeredAt: Date;
 }): UserResponse => ({
   id: user.id,
@@ -19,6 +21,8 @@ const toResponse = (user: {
   mbtiType: user.mbtiType,
   level: user.level,
   kindnessTotal: user.kindnessTotal,
+  penaltyCount: user.penaltyCount,
+  isRestricted: user.isRestricted,
   registeredAt: user.registeredAt,
 });
 

--- a/backend/src/types/index.ts
+++ b/backend/src/types/index.ts
@@ -17,6 +17,8 @@ export interface UserResponse {
   mbtiType: string | null;
   level: number;
   kindnessTotal: number;
+  penaltyCount: number;
+  isRestricted: boolean;
   registeredAt: Date;
 }
 
@@ -31,9 +33,20 @@ export interface PostResponse {
   createdAt: Date;
 }
 
-export interface ThankResponse {
+export interface CommentResponse {
   id: number;
   postId: number;
+  userId: number;
+  authorNickname: string | null;
+  text: string;
+  isHidden: boolean;
+  createdAt: Date;
+  thankCount: number;
+}
+
+export interface ThankResponse {
+  id: number;
+  commentId: number;
   fromUserId: number;
   toUserId: number;
   message: string | null;

--- a/backend/src/types/index.ts
+++ b/backend/src/types/index.ts
@@ -19,6 +19,7 @@ export interface UserResponse {
   kindnessTotal: number;
   penaltyCount: number;
   isRestricted: boolean;
+  reDiagnosisNeeded: boolean;
   registeredAt: Date;
 }
 
@@ -42,6 +43,7 @@ export interface CommentResponse {
   isHidden: boolean;
   createdAt: Date;
   thankCount: number;
+  isThankedByAuthor: boolean;
 }
 
 export interface ThankResponse {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
+        "react-icons": "^5.6.0",
         "react-router-dom": "^6.27.0"
       },
       "devDependencies": {
@@ -1540,6 +1541,15 @@
       },
       "peerDependencies": {
         "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-icons": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.6.0.tgz",
+      "integrity": "sha512-RH93p5ki6LfOiIt0UtDyNg/cee+HLVR6cHHtW3wALfo+eOHTp8RnU2kRkI6E+H19zMIs03DyxUG/GfZMOGvmiA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "*"
       }
     },
     "node_modules/react-refresh": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,6 +10,7 @@
   "dependencies": {
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
+    "react-icons": "^5.6.0",
     "react-router-dom": "^6.27.0"
   },
   "devDependencies": {

--- a/frontend/src/api/avatar.ts
+++ b/frontend/src/api/avatar.ts
@@ -1,0 +1,5 @@
+import { request } from './client';
+import type { Avatar } from '../types';
+
+export const getAvatar = (userId: number): Promise<Avatar> =>
+  request<Avatar>(`/users/${userId}/avatar`);

--- a/frontend/src/api/comments.ts
+++ b/frontend/src/api/comments.ts
@@ -1,0 +1,11 @@
+import { request } from './client';
+import type { Comment } from '../types';
+
+export const createComment = (postId: number, userId: number, text: string): Promise<Comment> =>
+  request<Comment>(`/posts/${postId}/comments`, {
+    method: 'POST',
+    body: JSON.stringify({ userId, text }),
+  });
+
+export const listComments = (postId: number): Promise<Comment[]> =>
+  request<Comment[]>(`/posts/${postId}/comments`);

--- a/frontend/src/api/thanks.ts
+++ b/frontend/src/api/thanks.ts
@@ -1,15 +1,11 @@
 import { request } from './client';
 import type { Thank } from '../types';
 
-export const sendThank = (
-  postId: number,
-  fromUserId: number,
-  message?: string,
-): Promise<Thank> =>
-  request(`/posts/${postId}/thank`, {
+export const sendThank = (commentId: number, fromUserId: number, message?: string): Promise<Thank> =>
+  request<Thank>(`/comments/${commentId}/thank`, {
     method: 'POST',
     body: JSON.stringify({ fromUserId, message }),
   });
 
-export const listThanks = (postId: number): Promise<Thank[]> =>
-  request(`/posts/${postId}/thanks`);
+export const listThanks = (commentId: number): Promise<Thank[]> =>
+  request<Thank[]>(`/comments/${commentId}/thanks`);

--- a/frontend/src/components/AvatarCard.tsx
+++ b/frontend/src/components/AvatarCard.tsx
@@ -1,5 +1,6 @@
 import type { Avatar } from '../types';
 import { moodConfig } from '../utils/moodConfig';
+import { MoodBubble } from './MoodBubble';
 import type { WeatherMood } from '../types';
 
 const EXPRESSION_LABELS: Record<string, string> = {
@@ -33,15 +34,12 @@ interface Props {
 
 export const AvatarCard = ({ avatar }: Props) => {
   const mc = moodConfig[avatar.mood as WeatherMood] ?? moodConfig.CLOUDY;
-  const Icon = mc.icon;
   const expressionLabel = EXPRESSION_LABELS[avatar.expression] ?? avatar.expression;
   const styleLabel = COMMENT_STYLE_LABELS[avatar.commentStyle] ?? avatar.commentStyle;
 
   return (
     <div style={{ ...styles.card, background: mc.color, borderColor: mc.border }}>
-      <div style={{ ...styles.iconWrap, color: mc.text }}>
-        <Icon size={56} />
-      </div>
+      <MoodBubble mood={avatar.mood} size={40} />
       <div style={styles.info}>
         <div style={styles.levelBadge}>Lv.{avatar.level}</div>
         <div style={{ ...styles.moodLabel, color: mc.text }}>{mc.label}</div>
@@ -62,7 +60,6 @@ const styles: Record<string, React.CSSProperties> = {
     padding: '1rem 1.25rem',
     marginBottom: '1.25rem',
   },
-  iconWrap: { flexShrink: 0, display: 'flex', alignItems: 'center' },
   info: { flex: 1 },
   levelBadge: {
     display: 'inline-block',

--- a/frontend/src/components/AvatarCard.tsx
+++ b/frontend/src/components/AvatarCard.tsx
@@ -1,0 +1,80 @@
+import type { Avatar } from '../types';
+import { moodConfig } from '../utils/moodConfig';
+import type { WeatherMood } from '../types';
+
+const EXPRESSION_LABELS: Record<string, string> = {
+  NEUTRAL: 'おだやか',
+  HAPPY: 'うれしい',
+  SAD: 'かなしい',
+  ANXIOUS: 'そわそわ',
+  ANGRY: 'もやもや',
+  HOPEFUL: 'わくわく',
+  GENTLE: 'おだやか',
+  CURIOUS: 'わくわく好奇心旺盛',
+  DREAMY: 'ゆったり夢見がち',
+  DETERMINED: 'きりっとした',
+  CHEERFUL: '元気いっぱい',
+  ENERGETIC: 'エネルギッシュ',
+};
+
+const COMMENT_STYLE_LABELS: Record<string, string> = {
+  GENTLE: 'やさしい',
+  LOGICAL: 'おだやか・論理的',
+  CHEERFUL: '明るい',
+  CALM: '落ち着いた',
+  WARM: '温かみのある',
+  DIRECT: 'ストレートな',
+  ENERGETIC: '元気あふれる',
+};
+
+interface Props {
+  avatar: Avatar;
+}
+
+export const AvatarCard = ({ avatar }: Props) => {
+  const mc = moodConfig[avatar.mood as WeatherMood] ?? moodConfig.CLOUDY;
+  const Icon = mc.icon;
+  const expressionLabel = EXPRESSION_LABELS[avatar.expression] ?? avatar.expression;
+  const styleLabel = COMMENT_STYLE_LABELS[avatar.commentStyle] ?? avatar.commentStyle;
+
+  return (
+    <div style={{ ...styles.card, background: mc.color, borderColor: mc.border }}>
+      <div style={{ ...styles.iconWrap, color: mc.text }}>
+        <Icon size={56} />
+      </div>
+      <div style={styles.info}>
+        <div style={styles.levelBadge}>Lv.{avatar.level}</div>
+        <div style={{ ...styles.moodLabel, color: mc.text }}>{mc.label}</div>
+        <div style={styles.expression}>{expressionLabel}な気持ち</div>
+        <div style={styles.style}>{styleLabel}なあなた</div>
+      </div>
+    </div>
+  );
+};
+
+const styles: Record<string, React.CSSProperties> = {
+  card: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: '1rem',
+    border: '1px solid',
+    borderRadius: '14px',
+    padding: '1rem 1.25rem',
+    marginBottom: '1.25rem',
+  },
+  iconWrap: { flexShrink: 0, display: 'flex', alignItems: 'center' },
+  info: { flex: 1 },
+  levelBadge: {
+    display: 'inline-block',
+    background: '#2d7a4f',
+    color: '#fff',
+    fontSize: '0.72rem',
+    fontWeight: 700,
+    padding: '1px 8px',
+    borderRadius: '10px',
+    marginBottom: '0.3rem',
+  },
+  moodLabel: { fontSize: '1.1rem', fontWeight: 700, lineHeight: 1.2 },
+  expression: { fontSize: '0.85rem', color: '#555', marginTop: '0.2rem' },
+  style: { fontSize: '0.78rem', color: '#888', marginTop: '0.15rem' },
+};

--- a/frontend/src/components/CommentSection.tsx
+++ b/frontend/src/components/CommentSection.tsx
@@ -1,0 +1,144 @@
+import { useState, useEffect } from 'react';
+import { useAuth } from '../context/AuthContext';
+import { listComments, createComment } from '../api/comments';
+import { sendThank } from '../api/thanks';
+import { ApiError } from '../api/client';
+import type { Comment } from '../types';
+
+interface Props {
+  postId: number;
+}
+
+export const CommentSection = ({ postId }: Props) => {
+  const { user } = useAuth();
+  const [open, setOpen] = useState(false);
+  const [comments, setComments] = useState<Comment[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [text, setText] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [submitError, setSubmitError] = useState('');
+  const [thankedIds, setThankedIds] = useState<Set<number>>(new Set());
+
+  useEffect(() => {
+    if (!open) return;
+    setLoading(true);
+    listComments(postId)
+      .then(setComments)
+      .catch(() => { /* ignore */ })
+      .finally(() => setLoading(false));
+  }, [open, postId]);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!user || !text.trim()) return;
+    setSubmitting(true);
+    setSubmitError('');
+    try {
+      const comment = await createComment(postId, user.id, text.trim());
+      setComments((prev) => [...prev, comment]);
+      setText('');
+    } catch (err) {
+      setSubmitError(err instanceof ApiError ? err.message : 'コメントの投稿に失敗しました。');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const handleThank = async (commentId: number) => {
+    if (!user || thankedIds.has(commentId)) return;
+    try {
+      await sendThank(commentId, user.id);
+      setThankedIds((prev) => new Set(prev).add(commentId));
+      setComments((prev) =>
+        prev.map((c) => c.id === commentId ? { ...c, thankCount: c.thankCount + 1 } : c),
+      );
+    } catch { /* 重複など無視 */ }
+  };
+
+  const commentCount = comments.length;
+
+  return (
+    <div style={styles.wrap}>
+      <button onClick={() => setOpen((o) => !o)} style={styles.toggle}>
+        💬 コメント{open ? 'を閉じる' : `を見る${commentCount > 0 ? `（${commentCount}件）` : ''}`}
+      </button>
+
+      {open && (
+        <div style={styles.body}>
+          {loading && <p style={styles.hint}>読み込み中...</p>}
+
+          {!loading && comments.length === 0 && (
+            <p style={styles.hint}>まだコメントがありません。最初のコメントをどうぞ。</p>
+          )}
+
+          {comments.map((c) => (
+            <div key={c.id} style={styles.comment}>
+              <div style={styles.commentHeader}>
+                <span style={styles.author}>{c.authorNickname ?? '名無し'}</span>
+                <time style={styles.date}>
+                  {new Date(c.createdAt).toLocaleDateString('ja-JP', { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' })}
+                </time>
+                {user && user.id !== c.userId && (
+                  <button
+                    onClick={() => handleThank(c.id)}
+                    disabled={thankedIds.has(c.id)}
+                    style={{ ...styles.thankBtn, opacity: thankedIds.has(c.id) ? 0.5 : 1 }}
+                  >
+                    {thankedIds.has(c.id) ? '💛 送った' : '💛 ありがとう'}
+                    {c.thankCount > 0 && <span style={styles.thankCount}> {c.thankCount}</span>}
+                  </button>
+                )}
+                {user && user.id === c.userId && c.thankCount > 0 && (
+                  <span style={styles.thankReceived}>💛 {c.thankCount}</span>
+                )}
+              </div>
+              <p style={styles.commentText}>{c.text}</p>
+            </div>
+          ))}
+
+          {user && (
+            user.isRestricted ? (
+              <p style={styles.restricted}>⚠️ 違反が繰り返されたため、コメントの投稿が制限されています。</p>
+            ) : (
+              <form onSubmit={handleSubmit} style={styles.form}>
+                <textarea
+                  style={styles.textarea}
+                  rows={2}
+                  value={text}
+                  onChange={(e) => setText(e.target.value)}
+                  placeholder="コメントを入力... (最大200文字)"
+                  maxLength={200}
+                  required
+                />
+                {submitError && <p style={styles.error}>{submitError}</p>}
+                <button type="submit" disabled={submitting} style={styles.submitBtn}>
+                  {submitting ? '送信中...' : '送信'}
+                </button>
+              </form>
+            )
+          )}
+        </div>
+      )}
+    </div>
+  );
+};
+
+const styles: Record<string, React.CSSProperties> = {
+  wrap: { marginTop: '0.75rem', borderTop: '1px solid #f0f0f0', paddingTop: '0.6rem' },
+  toggle: { background: 'none', border: 'none', cursor: 'pointer', fontSize: '0.85rem', color: '#888', padding: '0' },
+  body: { marginTop: '0.75rem', display: 'flex', flexDirection: 'column', gap: '0.5rem' },
+  hint: { fontSize: '0.82rem', color: '#bbb', margin: 0 },
+  comment: { background: '#f9f9f9', borderRadius: '8px', padding: '0.6rem 0.8rem' },
+  commentHeader: { display: 'flex', alignItems: 'center', gap: '0.5rem', marginBottom: '0.25rem', flexWrap: 'wrap' as const },
+  author: { fontWeight: 600, fontSize: '0.82rem', color: '#555' },
+  date: { fontSize: '0.75rem', color: '#bbb' },
+  thankBtn: { marginLeft: 'auto', background: 'none', border: '1px solid #f9c74f', borderRadius: '4px', padding: '1px 8px', cursor: 'pointer', fontSize: '0.78rem', color: '#e09000', fontWeight: 600 },
+  thankCount: { fontSize: '0.75rem' },
+  thankReceived: { marginLeft: 'auto', fontSize: '0.8rem', color: '#e09000' },
+  commentText: { margin: 0, fontSize: '0.88rem', color: '#444', lineHeight: 1.5 },
+  form: { display: 'flex', flexDirection: 'column', gap: '0.4rem', marginTop: '0.25rem' },
+  textarea: { padding: '0.5rem 0.75rem', borderRadius: '6px', border: '1px solid #ddd', fontSize: '0.88rem', resize: 'vertical', outline: 'none' },
+  error: { color: '#c00', fontSize: '0.82rem', margin: 0 },
+  submitBtn: { alignSelf: 'flex-end', padding: '0.4rem 1.2rem', background: '#2d7a4f', color: '#fff', border: 'none', borderRadius: '6px', fontSize: '0.88rem', fontWeight: 600, cursor: 'pointer' },
+  restricted: { fontSize: '0.82rem', color: '#c00', background: '#fff5f5', borderRadius: '6px', padding: '0.5rem 0.75rem', border: '1px solid #fca5a5' },
+};

--- a/frontend/src/components/CommentSection.tsx
+++ b/frontend/src/components/CommentSection.tsx
@@ -8,9 +8,10 @@ import { FiMessageCircle, FiHeart, FiAlertTriangle } from 'react-icons/fi';
 
 interface Props {
   postId: number;
+  postAuthorId: number;
 }
 
-export const CommentSection = ({ postId }: Props) => {
+export const CommentSection = ({ postId, postAuthorId }: Props) => {
   const { user } = useAuth();
   const [open, setOpen] = useState(false);
   const [comments, setComments] = useState<Comment[]>([]);
@@ -80,7 +81,7 @@ export const CommentSection = ({ postId }: Props) => {
                 <time style={styles.date}>
                   {new Date(c.createdAt).toLocaleDateString('ja-JP', { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' })}
                 </time>
-                {user && user.id !== c.userId && (
+                {user && user.id === postAuthorId && user.id !== c.userId && (
                   <button
                     onClick={() => handleThank(c.id)}
                     disabled={thankedIds.has(c.id)}

--- a/frontend/src/components/CommentSection.tsx
+++ b/frontend/src/components/CommentSection.tsx
@@ -4,6 +4,7 @@ import { listComments, createComment } from '../api/comments';
 import { sendThank } from '../api/thanks';
 import { ApiError } from '../api/client';
 import type { Comment } from '../types';
+import { FiMessageCircle, FiHeart, FiAlertTriangle } from 'react-icons/fi';
 
 interface Props {
   postId: number;
@@ -60,7 +61,8 @@ export const CommentSection = ({ postId }: Props) => {
   return (
     <div style={styles.wrap}>
       <button onClick={() => setOpen((o) => !o)} style={styles.toggle}>
-        💬 コメント{open ? 'を閉じる' : `を見る${commentCount > 0 ? `（${commentCount}件）` : ''}`}
+        <FiMessageCircle size={14} style={{ verticalAlign: 'middle', marginRight: 4 }} />
+        コメント{open ? 'を閉じる' : `を見る${commentCount > 0 ? `（${commentCount}件）` : ''}`}
       </button>
 
       {open && (
@@ -84,12 +86,13 @@ export const CommentSection = ({ postId }: Props) => {
                     disabled={thankedIds.has(c.id)}
                     style={{ ...styles.thankBtn, opacity: thankedIds.has(c.id) ? 0.5 : 1 }}
                   >
-                    {thankedIds.has(c.id) ? '💛 送った' : '💛 ありがとう'}
+                    <FiHeart size={12} style={{ verticalAlign: 'middle', marginRight: 3 }} />
+                    {thankedIds.has(c.id) ? '送った' : 'ありがとう'}
                     {c.thankCount > 0 && <span style={styles.thankCount}> {c.thankCount}</span>}
                   </button>
                 )}
                 {user && user.id === c.userId && c.thankCount > 0 && (
-                  <span style={styles.thankReceived}>💛 {c.thankCount}</span>
+                  <span style={styles.thankReceived}><FiHeart size={12} style={{ verticalAlign: 'middle', marginRight: 2 }} /> {c.thankCount}</span>
                 )}
               </div>
               <p style={styles.commentText}>{c.text}</p>
@@ -98,7 +101,7 @@ export const CommentSection = ({ postId }: Props) => {
 
           {user && (
             user.isRestricted ? (
-              <p style={styles.restricted}>⚠️ 違反が繰り返されたため、コメントの投稿が制限されています。</p>
+              <p style={styles.restricted}><FiAlertTriangle size={14} style={{ verticalAlign: 'middle', marginRight: 4 }} /> 違反が繰り返されたため、コメントの投稿が制限されています。</p>
             ) : (
               <form onSubmit={handleSubmit} style={styles.form}>
                 <textarea

--- a/frontend/src/components/CommentSection.tsx
+++ b/frontend/src/components/CommentSection.tsx
@@ -52,12 +52,14 @@ export const CommentSection = ({ postId, postAuthorId }: Props) => {
       await sendThank(commentId, user.id);
       setThankedIds((prev) => new Set(prev).add(commentId));
       setComments((prev) =>
-        prev.map((c) => c.id === commentId ? { ...c, thankCount: c.thankCount + 1 } : c),
+        prev.map((c) => c.id === commentId ? { ...c, thankCount: c.thankCount + 1, isThankedByAuthor: true } : c),
       );
     } catch { /* 重複など無視 */ }
   };
 
   const commentCount = comments.length;
+  const authorThanksUsed = comments.filter((c) => c.isThankedByAuthor || thankedIds.has(c.id)).length;
+  const thankLimitReached = authorThanksUsed >= 5;
 
   return (
     <div style={styles.wrap}>
@@ -84,11 +86,12 @@ export const CommentSection = ({ postId, postAuthorId }: Props) => {
                 {user && user.id === postAuthorId && user.id !== c.userId && (
                   <button
                     onClick={() => handleThank(c.id)}
-                    disabled={thankedIds.has(c.id)}
-                    style={{ ...styles.thankBtn, opacity: thankedIds.has(c.id) ? 0.5 : 1 }}
+                    disabled={c.isThankedByAuthor || thankedIds.has(c.id) || thankLimitReached}
+                    style={{ ...styles.thankBtn, opacity: (c.isThankedByAuthor || thankedIds.has(c.id) || thankLimitReached) ? 0.5 : 1 }}
+                    title={thankLimitReached && !c.isThankedByAuthor && !thankedIds.has(c.id) ? 'この投稿のありがとうは5件までです' : undefined}
                   >
                     <FiHeart size={12} style={{ verticalAlign: 'middle', marginRight: 3 }} />
-                    {thankedIds.has(c.id) ? '送った' : 'ありがとう'}
+                    {c.isThankedByAuthor || thankedIds.has(c.id) ? '送った' : 'ありがとう'}
                     {c.thankCount > 0 && <span style={styles.thankCount}> {c.thankCount}</span>}
                   </button>
                 )}
@@ -99,6 +102,10 @@ export const CommentSection = ({ postId, postAuthorId }: Props) => {
               <p style={styles.commentText}>{c.text}</p>
             </div>
           ))}
+
+          {user && user.id === postAuthorId && thankLimitReached && (
+            <p style={styles.thankLimitNote}>この投稿へのありがとうは5件送りました。</p>
+          )}
 
           {user && (
             user.isRestricted ? (
@@ -145,4 +152,5 @@ const styles: Record<string, React.CSSProperties> = {
   error: { color: '#c00', fontSize: '0.82rem', margin: 0 },
   submitBtn: { alignSelf: 'flex-end', padding: '0.4rem 1.2rem', background: '#2d7a4f', color: '#fff', border: 'none', borderRadius: '6px', fontSize: '0.88rem', fontWeight: 600, cursor: 'pointer' },
   restricted: { fontSize: '0.82rem', color: '#c00', background: '#fff5f5', borderRadius: '6px', padding: '0.5rem 0.75rem', border: '1px solid #fca5a5' },
+  thankLimitNote: { fontSize: '0.78rem', color: '#e09000', margin: '0.25rem 0', textAlign: 'right' as const },
 };

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -2,6 +2,8 @@ import { ReactNode, useEffect, useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { useAuth } from '../context/AuthContext';
 import { listNotifications } from '../api/notifications';
+import { FaLeaf } from 'react-icons/fa';
+import { FiUsers, FiCloud, FiBookOpen, FiEye, FiBell, FiUser } from 'react-icons/fi';
 
 export const Layout = ({ children }: { children: ReactNode }) => {
   const { user, setUser } = useAuth();
@@ -23,19 +25,20 @@ export const Layout = ({ children }: { children: ReactNode }) => {
   return (
     <div style={{ minHeight: '100vh', background: '#f8f9fa' }}>
       <header style={styles.header}>
-        <Link to="/" style={styles.logo}>🌱 Habitora</Link>
+        <Link to="/" style={styles.logo}><FaLeaf style={{ verticalAlign: 'middle', marginRight: 6 }} /> Habitora</Link>
         <nav style={styles.nav}>
           {user ? (
             <>
-              <Link to="/timeline" style={styles.navLink}>👥 みんなの投稿</Link>
-              <Link to="/forecast" style={styles.navLink}>⛅ 天気予報</Link>
-              <Link to="/reviews" style={styles.navLink}>📖 ふり返り</Link>
-              <Link to="/consultation" style={styles.navLink}>🪞 こころの鏡</Link>
+              <Link to="/timeline" style={styles.navLink}><FiUsers style={styles.navIcon} /> みんなの投稿</Link>
+              <Link to="/forecast" style={styles.navLink}><FiCloud style={styles.navIcon} /> 天気予報</Link>
+              <Link to="/reviews" style={styles.navLink}><FiBookOpen style={styles.navIcon} /> ふり返り</Link>
+              <Link to="/consultation" style={styles.navLink}><FiEye style={styles.navIcon} /> こころの鏡</Link>
               <Link to="/notifications" style={styles.navLink}>
-                🔔
+                <FiBell size={18} />
                 {unreadCount > 0 && <span style={styles.badge}>{unreadCount}</span>}
               </Link>
               <Link to="/profile" style={styles.navLink}>
+                <FiUser style={{ verticalAlign: 'middle', marginRight: 4 }} />
                 {user.nickname ?? user.email.split('@')[0]}
               </Link>
               <button onClick={handleLogout} style={styles.logoutBtn}>ログアウト</button>
@@ -70,7 +73,8 @@ const styles: Record<string, React.CSSProperties> = {
     textDecoration: 'none',
   },
   nav: { display: 'flex', alignItems: 'center', gap: '1rem', flexWrap: 'wrap' },
-  navLink: { color: '#555', textDecoration: 'none', fontSize: '0.9rem', position: 'relative' as const },
+  navLink: { color: '#555', textDecoration: 'none', fontSize: '0.9rem', position: 'relative' as const, display: 'inline-flex', alignItems: 'center', gap: '0.3rem' },
+  navIcon: { flexShrink: 0 },
   badge: {
     position: 'absolute' as const,
     top: '-6px',

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -2,8 +2,7 @@ import { ReactNode, useEffect, useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { useAuth } from '../context/AuthContext';
 import { listNotifications } from '../api/notifications';
-import { FaLeaf } from 'react-icons/fa';
-import { FiUsers, FiCloud, FiBookOpen, FiEye, FiBell, FiUser } from 'react-icons/fi';
+import { PiPlantFill, PiUsersFill, PiCloudFill, PiBookOpenTextFill, PiEyeFill, PiBellFill, PiUserFill } from 'react-icons/pi';
 
 export const Layout = ({ children }: { children: ReactNode }) => {
   const { user, setUser } = useAuth();
@@ -25,20 +24,20 @@ export const Layout = ({ children }: { children: ReactNode }) => {
   return (
     <div style={{ minHeight: '100vh', background: '#f8f9fa' }}>
       <header style={styles.header}>
-        <Link to="/" style={styles.logo}><FaLeaf style={{ verticalAlign: 'middle', marginRight: 6 }} /> Habitora</Link>
+        <Link to="/" style={styles.logo}><PiPlantFill style={{ verticalAlign: 'middle', marginRight: 6 }} /> Habitora</Link>
         <nav style={styles.nav}>
           {user ? (
             <>
-              <Link to="/timeline" style={styles.navLink}><FiUsers style={styles.navIcon} /> みんなの投稿</Link>
-              <Link to="/forecast" style={styles.navLink}><FiCloud style={styles.navIcon} /> 天気予報</Link>
-              <Link to="/reviews" style={styles.navLink}><FiBookOpen style={styles.navIcon} /> ふり返り</Link>
-              <Link to="/consultation" style={styles.navLink}><FiEye style={styles.navIcon} /> こころの鏡</Link>
+              <Link to="/timeline" style={styles.navLink}><PiUsersFill style={styles.navIcon} /> みんなの投稿</Link>
+              <Link to="/forecast" style={styles.navLink}><PiCloudFill style={styles.navIcon} /> 天気予報</Link>
+              <Link to="/reviews" style={styles.navLink}><PiBookOpenTextFill style={styles.navIcon} /> ふり返り</Link>
+              <Link to="/consultation" style={styles.navLink}><PiEyeFill style={styles.navIcon} /> こころの鏡</Link>
               <Link to="/notifications" style={styles.navLink}>
-                <FiBell size={18} />
+                <PiBellFill size={18} />
                 {unreadCount > 0 && <span style={styles.badge}>{unreadCount}</span>}
               </Link>
               <Link to="/profile" style={styles.navLink}>
-                <FiUser style={{ verticalAlign: 'middle', marginRight: 4 }} />
+                <PiUserFill style={{ verticalAlign: 'middle', marginRight: 4 }} />
                 {user.nickname ?? user.email.split('@')[0]}
               </Link>
               <button onClick={handleLogout} style={styles.logoutBtn}>ログアウト</button>

--- a/frontend/src/components/MoodBubble.tsx
+++ b/frontend/src/components/MoodBubble.tsx
@@ -1,0 +1,28 @@
+import { moodConfig } from '../utils/moodConfig';
+import type { WeatherMood } from '../types';
+
+interface Props {
+  mood: string;
+  size?: number;
+}
+
+export const MoodBubble = ({ mood, size = 24 }: Props) => {
+  const mc = moodConfig[mood as WeatherMood] ?? moodConfig.CLOUDY;
+  const Icon = mc.icon;
+  return (
+    <div style={{
+      background: mc.color,
+      border: `2px solid ${mc.border}`,
+      borderRadius: '50%',
+      width: size + 16,
+      height: size + 16,
+      display: 'inline-flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      color: mc.text,
+      flexShrink: 0,
+    }}>
+      <Icon size={size} />
+    </div>
+  );
+};

--- a/frontend/src/components/PostCard.tsx
+++ b/frontend/src/components/PostCard.tsx
@@ -1,7 +1,6 @@
-import { useState } from 'react';
 import type { Post, WeatherMood } from '../types';
-import { sendThank } from '../api/thanks';
 import { useAuth } from '../context/AuthContext';
+import { CommentSection } from './CommentSection';
 
 const moodConfig: Record<WeatherMood, { icon: string; label: string; color: string; border: string; text: string }> = {
   STORM:     { icon: '⛈️',  label: '嵐',       color: '#ffebee', border: '#ef9a9a', text: '#b71c1c' },
@@ -19,32 +18,16 @@ const moodConfig: Record<WeatherMood, { icon: string; label: string; color: stri
 interface Props {
   post: Post;
   onDelete?: (id: number) => void;
-  onThank?: (postId: number) => void;
-  showThankBtn?: boolean;
+  showComments?: boolean;
 }
 
-export const PostCard = ({ post, onDelete, showThankBtn }: Props) => {
+export const PostCard = ({ post, onDelete, showComments = true }: Props) => {
   const { user } = useAuth();
   const config = moodConfig[post.mood] ?? moodConfig.CLOUDY;
-  const [thankDone, setThankDone] = useState(false);
-  const [thankLoading, setThankLoading] = useState(false);
 
   const date = new Date(post.createdAt).toLocaleDateString('ja-JP', {
     year: 'numeric', month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit',
   });
-
-  const handleThank = async () => {
-    if (!user || thankDone) return;
-    setThankLoading(true);
-    try {
-      await sendThank(post.id, user.id);
-      setThankDone(true);
-    } catch {
-      // already thanked or self-post — ignore
-    } finally {
-      setThankLoading(false);
-    }
-  };
 
   return (
     <div style={{ ...styles.card, background: config.color, borderColor: config.border }}>
@@ -54,16 +37,7 @@ export const PostCard = ({ post, onDelete, showThankBtn }: Props) => {
         </span>
         <span style={styles.score}>スコア: {post.feelingScore}/100</span>
         <div style={styles.actions}>
-          {showThankBtn && user && user.id !== post.userId && (
-            <button
-              onClick={handleThank}
-              disabled={thankDone || thankLoading}
-              style={{ ...styles.thankBtn, opacity: thankDone ? 0.5 : 1 }}
-            >
-              {thankDone ? '💛 送った' : '💛 ありがとう'}
-            </button>
-          )}
-          {onDelete && (
+          {onDelete && user?.id === post.userId && (
             <button onClick={() => onDelete(post.id)} style={styles.deleteBtn}>削除</button>
           )}
         </div>
@@ -79,6 +53,8 @@ export const PostCard = ({ post, onDelete, showThankBtn }: Props) => {
         </div>
       )}
       <time style={styles.date}>{date}</time>
+
+      {showComments && <CommentSection postId={post.id} />}
     </div>
   );
 };
@@ -100,16 +76,6 @@ const styles: Record<string, React.CSSProperties> = {
   },
   score: { fontSize: '0.82rem', color: '#666' },
   actions: { display: 'flex', gap: '0.5rem', marginLeft: 'auto', alignItems: 'center' },
-  thankBtn: {
-    background: 'none',
-    border: '1px solid #f9c74f',
-    borderRadius: '4px',
-    padding: '2px 10px',
-    cursor: 'pointer',
-    fontSize: '0.8rem',
-    color: '#e09000',
-    fontWeight: 600,
-  },
   deleteBtn: {
     background: 'none',
     border: '1px solid #ccc',

--- a/frontend/src/components/PostCard.tsx
+++ b/frontend/src/components/PostCard.tsx
@@ -1,19 +1,8 @@
-import type { Post, WeatherMood } from '../types';
+import type { Post } from '../types';
 import { useAuth } from '../context/AuthContext';
 import { CommentSection } from './CommentSection';
-
-const moodConfig: Record<WeatherMood, { icon: string; label: string; color: string; border: string; text: string }> = {
-  STORM:     { icon: '⛈️',  label: '嵐',       color: '#ffebee', border: '#ef9a9a', text: '#b71c1c' },
-  RAIN:      { icon: '🌧️', label: '雨',       color: '#e3f2fd', border: '#90caf9', text: '#1565c0' },
-  SNOW:      { icon: '❄️',  label: '雪',       color: '#f3f8ff', border: '#b3d4f5', text: '#37474f' },
-  FOG:       { icon: '🌫️', label: '霧',       color: '#f5f5f5', border: '#bdbdbd', text: '#424242' },
-  CLOUDY:    { icon: '⛅',  label: 'くもり',   color: '#fff8e1', border: '#ffe082', text: '#5d4037' },
-  WHIRLWIND: { icon: '🌪️', label: 'つむじ風', color: '#fff3e0', border: '#ffcc80', text: '#e65100' },
-  SPROUT:    { icon: '🌻',  label: '芽吹き',   color: '#f1f8e9', border: '#aed581', text: '#33691e' },
-  RAINBOW:   { icon: '🌈',  label: '虹',       color: '#fce4ec', border: '#f48fb1', text: '#880e4f' },
-  STAR:      { icon: '🌟',  label: '星空',     color: '#e8eaf6', border: '#9fa8da', text: '#283593' },
-  SUNNY:     { icon: '☀️',  label: '晴れ',     color: '#e8f5e9', border: '#a5d6a7', text: '#1b5e20' },
-};
+import { moodConfig } from '../utils/moodConfig';
+import type { WeatherMood } from '../types';
 
 interface Props {
   post: Post;
@@ -23,7 +12,8 @@ interface Props {
 
 export const PostCard = ({ post, onDelete, showComments = true }: Props) => {
   const { user } = useAuth();
-  const config = moodConfig[post.mood] ?? moodConfig.CLOUDY;
+  const config = moodConfig[post.mood as WeatherMood] ?? moodConfig.CLOUDY;
+  const Icon = config.icon;
 
   const date = new Date(post.createdAt).toLocaleDateString('ja-JP', {
     year: 'numeric', month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit',
@@ -33,7 +23,8 @@ export const PostCard = ({ post, onDelete, showComments = true }: Props) => {
     <div style={{ ...styles.card, background: config.color, borderColor: config.border }}>
       <div style={styles.header}>
         <span style={{ ...styles.moodBadge, color: config.text, borderColor: config.border }}>
-          {config.icon} {config.label}
+          <Icon size={20} style={{ verticalAlign: 'middle', marginRight: 4 }} />
+          {config.label}
         </span>
         <span style={styles.score}>スコア: {post.feelingScore}/100</span>
         <div style={styles.actions}>
@@ -68,6 +59,8 @@ const styles: Record<string, React.CSSProperties> = {
   },
   header: { display: 'flex', alignItems: 'center', gap: '0.75rem', marginBottom: '0.6rem', flexWrap: 'wrap' },
   moodBadge: {
+    display: 'inline-flex',
+    alignItems: 'center',
     fontSize: '0.9rem',
     fontWeight: 600,
     border: '1px solid',

--- a/frontend/src/components/PostCard.tsx
+++ b/frontend/src/components/PostCard.tsx
@@ -2,7 +2,9 @@ import type { Post } from '../types';
 import { useAuth } from '../context/AuthContext';
 import { CommentSection } from './CommentSection';
 import { moodConfig } from '../utils/moodConfig';
+import { MoodBubble } from './MoodBubble';
 import type { WeatherMood } from '../types';
+import { FiTrash2 } from 'react-icons/fi';
 
 interface Props {
   post: Post;
@@ -13,7 +15,6 @@ interface Props {
 export const PostCard = ({ post, onDelete, showComments = true }: Props) => {
   const { user } = useAuth();
   const config = moodConfig[post.mood as WeatherMood] ?? moodConfig.CLOUDY;
-  const Icon = config.icon;
 
   const date = new Date(post.createdAt).toLocaleDateString('ja-JP', {
     year: 'numeric', month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit',
@@ -22,14 +23,15 @@ export const PostCard = ({ post, onDelete, showComments = true }: Props) => {
   return (
     <div style={{ ...styles.card, background: config.color, borderColor: config.border }}>
       <div style={styles.header}>
-        <span style={{ ...styles.moodBadge, color: config.text, borderColor: config.border }}>
-          <Icon size={20} style={{ verticalAlign: 'middle', marginRight: 4 }} />
-          {config.label}
-        </span>
+        <MoodBubble mood={post.mood} size={20} />
+        <span style={{ ...styles.moodLabel, color: config.text }}>{config.label}</span>
         <span style={styles.score}>スコア: {post.feelingScore}/100</span>
         <div style={styles.actions}>
           {onDelete && user?.id === post.userId && (
-            <button onClick={() => onDelete(post.id)} style={styles.deleteBtn}>削除</button>
+            <button onClick={() => onDelete(post.id)} style={styles.deleteBtn}>
+              <FiTrash2 size={13} style={{ verticalAlign: 'middle', marginRight: 3 }} />
+              削除
+            </button>
           )}
         </div>
       </div>
@@ -57,19 +59,13 @@ const styles: Record<string, React.CSSProperties> = {
     padding: '1.2rem',
     marginBottom: '1rem',
   },
-  header: { display: 'flex', alignItems: 'center', gap: '0.75rem', marginBottom: '0.6rem', flexWrap: 'wrap' },
-  moodBadge: {
-    display: 'inline-flex',
-    alignItems: 'center',
-    fontSize: '0.9rem',
-    fontWeight: 600,
-    border: '1px solid',
-    borderRadius: '20px',
-    padding: '3px 12px',
-  },
+  header: { display: 'flex', alignItems: 'center', gap: '0.5rem', marginBottom: '0.6rem', flexWrap: 'wrap' },
+  moodLabel: { fontSize: '0.9rem', fontWeight: 700 },
   score: { fontSize: '0.82rem', color: '#666' },
   actions: { display: 'flex', gap: '0.5rem', marginLeft: 'auto', alignItems: 'center' },
   deleteBtn: {
+    display: 'inline-flex',
+    alignItems: 'center',
     background: 'none',
     border: '1px solid #ccc',
     borderRadius: '4px',

--- a/frontend/src/components/PostCard.tsx
+++ b/frontend/src/components/PostCard.tsx
@@ -45,7 +45,7 @@ export const PostCard = ({ post, onDelete, showComments = true }: Props) => {
       )}
       <time style={styles.date}>{date}</time>
 
-      {showComments && <CommentSection postId={post.id} />}
+      {showComments && <CommentSection postId={post.id} postAuthorId={post.userId} />}
     </div>
   );
 };

--- a/frontend/src/pages/ConsultationPage.tsx
+++ b/frontend/src/pages/ConsultationPage.tsx
@@ -3,13 +3,15 @@ import { useAuth } from '../context/AuthContext';
 import { useNavigate } from 'react-router-dom';
 import { createConsultation, listConsultations, archiveConsultation } from '../api/consultation';
 import type { Consultation } from '../types';
+import { FiEye, FiMessageCircle, FiStar, FiFrown, FiAlertCircle, FiMessageSquare, FiSearch, FiEdit2 } from 'react-icons/fi';
+import type { IconType } from 'react-icons';
 
-const THEMES = [
-  { key: '悩み', label: '😔 悩み' },
-  { key: '不安', label: '😰 不安' },
-  { key: '感情整理', label: '💭 感情整理' },
-  { key: '自己理解', label: '🔍 自己理解' },
-  { key: 'その他', label: '✏️ その他' },
+const THEMES: { key: string; label: string; icon: IconType }[] = [
+  { key: '悩み',    label: '悩み',    icon: FiFrown },
+  { key: '不安',    label: '不安',    icon: FiAlertCircle },
+  { key: '感情整理',label: '感情整理',icon: FiMessageSquare },
+  { key: '自己理解',label: '自己理解',icon: FiSearch },
+  { key: 'その他',  label: 'その他',  icon: FiEdit2 },
 ];
 
 export const ConsultationPage = () => {
@@ -64,23 +66,27 @@ export const ConsultationPage = () => {
 
   return (
     <div>
-      <h2 style={styles.heading}>🪞 こころの鏡</h2>
+      <h2 style={styles.heading}><FiEye size={20} style={{ verticalAlign: 'middle', marginRight: 8 }} /> こころの鏡</h2>
 
       {!activeConsultation ? (
         <form onSubmit={handleSubmit} style={styles.form}>
           <p style={styles.desc}>今の気持ちをテーマを選んで話しかけてみてください。</p>
 
           <div style={styles.themeRow}>
-            {THEMES.map((t) => (
-              <button
-                key={t.key}
-                type="button"
-                onClick={() => setTheme(t.key)}
-                style={{ ...styles.themeChip, ...(theme === t.key ? styles.themeChipActive : {}) }}
-              >
-                {t.label}
-              </button>
-            ))}
+            {THEMES.map((t) => {
+              const TI = t.icon;
+              return (
+                <button
+                  key={t.key}
+                  type="button"
+                  onClick={() => setTheme(t.key)}
+                  style={{ ...styles.themeChip, ...(theme === t.key ? styles.themeChipActive : {}) }}
+                >
+                  <TI size={14} style={{ verticalAlign: 'middle', marginRight: 4 }} />
+                  {t.label}
+                </button>
+              );
+            })}
           </div>
 
           <textarea
@@ -95,13 +101,13 @@ export const ConsultationPage = () => {
           {submitError && <p style={styles.error}>{submitError}</p>}
 
           <button type="submit" disabled={submitting} style={styles.submitBtn}>
-            {submitting ? '送信中...' : '💬 話しかける'}
+            {submitting ? '送信中...' : <><FiMessageCircle size={16} style={{ verticalAlign: 'middle', marginRight: 6 }} /> 話しかける</>}
           </button>
         </form>
       ) : (
         <div style={styles.guidanceBox}>
           {activeConsultation.avatarReaction && (
-            <p style={styles.avatarReaction}>💬 {activeConsultation.avatarReaction}</p>
+            <p style={styles.avatarReaction}><FiMessageCircle size={14} style={{ verticalAlign: 'middle', marginRight: 4 }} /> {activeConsultation.avatarReaction}</p>
           )}
 
           <div style={styles.stepProgress}>
@@ -123,7 +129,7 @@ export const ConsultationPage = () => {
             ) : (
               <div style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem', flex: 1 }}>
                 {activeConsultation.insightSummary && (
-                  <p style={styles.insight}>✨ {activeConsultation.insightSummary}</p>
+                  <p style={styles.insight}><FiStar size={14} style={{ verticalAlign: 'middle', marginRight: 4 }} /> {activeConsultation.insightSummary}</p>
                 )}
                 <button onClick={() => setActiveConsultation(null)} style={{ ...styles.stepBtn, ...styles.stepBtnPrimary }}>
                   新しい相談をする

--- a/frontend/src/pages/ConsultationPage.tsx
+++ b/frontend/src/pages/ConsultationPage.tsx
@@ -3,15 +3,16 @@ import { useAuth } from '../context/AuthContext';
 import { useNavigate } from 'react-router-dom';
 import { createConsultation, listConsultations, archiveConsultation } from '../api/consultation';
 import type { Consultation } from '../types';
-import { FiEye, FiMessageCircle, FiStar, FiFrown, FiAlertCircle, FiMessageSquare, FiSearch, FiEdit2 } from 'react-icons/fi';
+import { FiEye, FiMessageCircle, FiStar, FiArchive } from 'react-icons/fi';
+import { PiSmileySadFill, PiWarningCircleFill, PiChatCenteredTextFill, PiMagnifyingGlassFill, PiPencilFill } from 'react-icons/pi';
 import type { IconType } from 'react-icons';
 
 const THEMES: { key: string; label: string; icon: IconType }[] = [
-  { key: '悩み',    label: '悩み',    icon: FiFrown },
-  { key: '不安',    label: '不安',    icon: FiAlertCircle },
-  { key: '感情整理',label: '感情整理',icon: FiMessageSquare },
-  { key: '自己理解',label: '自己理解',icon: FiSearch },
-  { key: 'その他',  label: 'その他',  icon: FiEdit2 },
+  { key: '悩み',    label: '悩み',    icon: PiSmileySadFill },
+  { key: '不安',    label: '不安',    icon: PiWarningCircleFill },
+  { key: '感情整理',label: '感情整理',icon: PiChatCenteredTextFill },
+  { key: '自己理解',label: '自己理解',icon: PiMagnifyingGlassFill },
+  { key: 'その他',  label: 'その他',  icon: PiPencilFill },
 ];
 
 export const ConsultationPage = () => {
@@ -151,7 +152,9 @@ export const ConsultationPage = () => {
                   <time style={styles.historyDate}>
                     {new Date(c.submittedAt).toLocaleDateString('ja-JP', { month: 'short', day: 'numeric' })}
                   </time>
-                  <button onClick={() => handleArchive(c.id)} style={styles.archiveBtn}>アーカイブ</button>
+                  <button onClick={() => handleArchive(c.id)} style={styles.archiveBtn}>
+                    <FiArchive size={12} style={{ verticalAlign: 'middle', marginRight: 3 }} />アーカイブ
+                  </button>
                 </div>
                 <p style={styles.historyContent}>{c.content.slice(0, 80)}{c.content.length > 80 ? '…' : ''}</p>
               </div>

--- a/frontend/src/pages/CreatePostPage.tsx
+++ b/frontend/src/pages/CreatePostPage.tsx
@@ -4,6 +4,8 @@ import { createPost } from '../api/posts';
 import { useAuth } from '../context/AuthContext';
 import { ApiError } from '../api/client';
 import type { WeatherMood } from '../types';
+import { moodConfig } from '../utils/moodConfig';
+import { FiGlobe } from 'react-icons/fi';
 
 const resolveMood = (score: number): WeatherMood => {
   if (score <= 10) return 'STORM';
@@ -18,17 +20,17 @@ const resolveMood = (score: number): WeatherMood => {
   return 'SUNNY';
 };
 
-const moodInfo: Record<WeatherMood, { icon: string; label: string; desc: string; color: string }> = {
-  STORM:     { icon: '⛈️',  label: '嵐',       desc: '怒り・動揺を感じています',     color: '#b71c1c' },
-  RAIN:      { icon: '🌧️', label: '雨',       desc: '悲しい・寂しい気持ちです',     color: '#1565c0' },
-  SNOW:      { icon: '❄️',  label: '雪',       desc: '静かな寂しさがあります',       color: '#37474f' },
-  FOG:       { icon: '🌫️', label: '霧',       desc: '混乱・疲れを感じています',     color: '#424242' },
-  CLOUDY:    { icon: '⛅',  label: 'くもり',   desc: 'ぼんやり・静かな気持ちです',   color: '#5d4037' },
-  WHIRLWIND: { icon: '🌪️', label: 'つむじ風', desc: '少し焦りを感じています',       color: '#e65100' },
-  SPROUT:    { icon: '🌻',  label: '芽吹き',   desc: '小さな前向きさがあります',     color: '#33691e' },
-  RAINBOW:   { icon: '🌈',  label: '虹',       desc: '癒し・希望を感じています',     color: '#880e4f' },
-  STAR:      { icon: '🌟',  label: '星空',     desc: '穏やかに思索しています',       color: '#283593' },
-  SUNNY:     { icon: '☀️',  label: '晴れ',     desc: '安心・前向きな気持ちです',     color: '#1b5e20' },
+const moodDesc: Record<WeatherMood, string> = {
+  STORM:     '怒り・動揺を感じています',
+  RAIN:      '悲しい・寂しい気持ちです',
+  SNOW:      '静かな寂しさがあります',
+  FOG:       '混乱・疲れを感じています',
+  CLOUDY:    'ぼんやり・静かな気持ちです',
+  WHIRLWIND: '少し焦りを感じています',
+  SPROUT:    '小さな前向きさがあります',
+  RAINBOW:   '癒し・希望を感じています',
+  STAR:      '穏やかに思索しています',
+  SUNNY:     '安心・前向きな気持ちです',
 };
 
 const MAX_CHARS = 250;
@@ -45,7 +47,9 @@ export const CreatePostPage = () => {
   const [loading, setLoading] = useState(false);
 
   const mood = resolveMood(feelingScore);
-  const info = moodInfo[mood];
+  const info = moodConfig[mood];
+  const desc = moodDesc[mood];
+  const MoodIcon = info.icon;
   const charsLeft = MAX_CHARS - text.length;
 
   const addKeyword = () => {
@@ -113,11 +117,11 @@ export const CreatePostPage = () => {
             <span>100 (最高)</span>
           </div>
 
-          <div style={{ ...styles.moodPreview, borderColor: info.color }}>
-            <span style={styles.moodIcon}>{info.icon}</span>
+          <div style={{ ...styles.moodPreview, borderColor: info.text }}>
+            <span style={styles.moodIcon}><MoodIcon size={36} color={info.text} /></span>
             <div>
-              <div style={{ fontWeight: 700, color: info.color }}>{info.label}</div>
-              <div style={{ fontSize: '0.82rem', color: '#666' }}>{info.desc}</div>
+              <div style={{ fontWeight: 700, color: info.text }}>{info.label}</div>
+              <div style={{ fontSize: '0.82rem', color: '#666' }}>{desc}</div>
             </div>
           </div>
 
@@ -150,7 +154,7 @@ export const CreatePostPage = () => {
 
           <label style={styles.visibleLabel}>
             <div style={styles.toggleRow}>
-              <span>👥 みんなに公開する</span>
+              <span style={{ display: 'inline-flex', alignItems: 'center', gap: '0.4rem' }}><FiGlobe size={16} /> みんなに公開する</span>
               <div
                 role="switch"
                 aria-checked={isVisible}

--- a/frontend/src/pages/CreatePostPage.tsx
+++ b/frontend/src/pages/CreatePostPage.tsx
@@ -5,7 +5,8 @@ import { useAuth } from '../context/AuthContext';
 import { ApiError } from '../api/client';
 import type { WeatherMood } from '../types';
 import { moodConfig } from '../utils/moodConfig';
-import { FiGlobe } from 'react-icons/fi';
+import { MoodBubble } from '../components/MoodBubble';
+import { FiGlobe, FiPlus, FiX } from 'react-icons/fi';
 
 const resolveMood = (score: number): WeatherMood => {
   if (score <= 10) return 'STORM';
@@ -47,9 +48,7 @@ export const CreatePostPage = () => {
   const [loading, setLoading] = useState(false);
 
   const mood = resolveMood(feelingScore);
-  const info = moodConfig[mood];
   const desc = moodDesc[mood];
-  const MoodIcon = info.icon;
   const charsLeft = MAX_CHARS - text.length;
 
   const addKeyword = () => {
@@ -117,10 +116,10 @@ export const CreatePostPage = () => {
             <span>100 (最高)</span>
           </div>
 
-          <div style={{ ...styles.moodPreview, borderColor: info.text }}>
-            <span style={styles.moodIcon}><MoodIcon size={36} color={info.text} /></span>
+          <div style={styles.moodPreview}>
+            <MoodBubble mood={mood} size={28} />
             <div>
-              <div style={{ fontWeight: 700, color: info.text }}>{info.label}</div>
+              <div style={{ fontWeight: 700, color: moodConfig[mood].text }}>{moodConfig[mood].label}</div>
               <div style={{ fontSize: '0.82rem', color: '#666' }}>{desc}</div>
             </div>
           </div>
@@ -135,7 +134,9 @@ export const CreatePostPage = () => {
               style={styles.tagInput}
               placeholder="例: 嬉しい、疲れた"
             />
-            <button type="button" onClick={addKeyword} style={styles.addBtn}>追加</button>
+            <button type="button" onClick={addKeyword} style={styles.addBtn}>
+              <FiPlus size={14} style={{ verticalAlign: 'middle', marginRight: 3 }} />追加
+            </button>
           </div>
           {keywords.length > 0 && (
             <div style={styles.tags}>
@@ -146,7 +147,7 @@ export const CreatePostPage = () => {
                     type="button"
                     onClick={() => setKeywords((prev) => prev.filter((k) => k !== kw))}
                     style={styles.removeTag}
-                  >×</button>
+                  ><FiX size={12} /></button>
                 </span>
               ))}
             </div>
@@ -189,10 +190,9 @@ const styles: Record<string, React.CSSProperties> = {
   sliderLabels: { display: 'flex', justifyContent: 'space-between', fontSize: '0.75rem', color: '#999', marginBottom: '0.5rem' },
   moodPreview: {
     display: 'flex', alignItems: 'center', gap: '1rem',
-    padding: '0.75rem 1rem', borderRadius: '8px', border: '2px solid',
+    padding: '0.75rem 1rem', borderRadius: '8px',
     background: '#fafafa', marginTop: '0.75rem',
   },
-  moodIcon: { fontSize: '2rem' },
   tagRow: { display: 'flex', gap: '0.5rem' },
   tagInput: { flex: 1, padding: '0.5rem 0.75rem', border: '1px solid #ddd', borderRadius: '6px', fontSize: '0.9rem' },
   addBtn: { padding: '0.5rem 1rem', background: '#e8f5e9', color: '#2d7a4f', border: '1px solid #a3d9a5', borderRadius: '6px', cursor: 'pointer', fontSize: '0.9rem' },

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -5,8 +5,8 @@ import { getAvatar } from '../api/avatar';
 import { useAuth } from '../context/AuthContext';
 import { PostCard } from '../components/PostCard';
 import { AvatarCard } from '../components/AvatarCard';
-import type { Post, Avatar, WeatherMood } from '../types';
-import { moodConfig } from '../utils/moodConfig';
+import type { Post, Avatar } from '../types';
+import { MoodBubble } from '../components/MoodBubble';
 import { FiStar, FiRefreshCw } from 'react-icons/fi';
 
 const MBTI_NAMES: Record<string, string> = {
@@ -104,14 +104,9 @@ export const DashboardPage = () => {
       {recentMoods.length > 0 && (
         <div style={styles.weatherRow}>
           <span style={styles.weatherLabel}>最近の天気:</span>
-          {recentMoods.map((mood, i) => {
-            const MoodIcon = (moodConfig[mood] ?? moodConfig.CLOUDY).icon;
-            return (
-              <span key={i} style={{ ...styles.weatherIcon, color: moodConfig[mood]?.text ?? '#555' }} title={mood}>
-                <MoodIcon size={24} />
-              </span>
-            );
-          })}
+          {recentMoods.map((mood, i) => (
+            <MoodBubble key={i} mood={mood} size={20} />
+          ))}
         </div>
       )}
 
@@ -149,7 +144,6 @@ const styles: Record<string, React.CSSProperties> = {
     marginBottom: '1.2rem', flexWrap: 'wrap',
   },
   weatherLabel: { fontSize: '0.82rem', color: '#888', marginRight: '0.25rem' },
-  weatherIcon: { display: 'inline-flex', cursor: 'default' },
   info: { textAlign: 'center', color: '#888' },
   errorText: { color: '#842029', background: '#fff0f0', padding: '0.6rem 1rem', borderRadius: '6px' },
   empty: { textAlign: 'center', padding: '3rem', color: '#888', background: '#fff', borderRadius: '12px' },

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -1,11 +1,13 @@
 import { useState, useEffect } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { getPostsByUser, deletePost } from '../api/posts';
+import { getAvatar } from '../api/avatar';
 import { useAuth } from '../context/AuthContext';
 import { PostCard } from '../components/PostCard';
-import type { Post, WeatherMood } from '../types';
+import { AvatarCard } from '../components/AvatarCard';
+import type { Post, Avatar, WeatherMood } from '../types';
 import { moodConfig } from '../utils/moodConfig';
-import { FiStar } from 'react-icons/fi';
+import { FiStar, FiRefreshCw } from 'react-icons/fi';
 
 const MBTI_NAMES: Record<string, string> = {
   INFP: '優しき理想家', INFJ: '静かな導き手', ISFP: '感性のアーティスト', ISFJ: '世話好きな癒し手',
@@ -14,10 +16,13 @@ const MBTI_NAMES: Record<string, string> = {
   ENTP: 'ひらめきの火花', ENTJ: 'ビジョンの指揮官', ESTP: 'アクションスター', ESTJ: '現実主義の管理者',
 };
 
+const DAYS_BEFORE_REMINDER = 7;
+
 export const DashboardPage = () => {
   const { user } = useAuth();
   const navigate = useNavigate();
   const [posts, setPosts] = useState<Post[]>([]);
+  const [avatar, setAvatar] = useState<Avatar | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState('');
 
@@ -26,9 +31,13 @@ export const DashboardPage = () => {
       navigate('/login');
       return;
     }
-    getPostsByUser(user.id)
-      .then(setPosts)
-      .catch(() => setError('投稿の取得に失敗しました。'))
+    Promise.all([
+      getPostsByUser(user.id),
+      getAvatar(user.id).catch(() => null),
+    ]).then(([userPosts, userAvatar]) => {
+      setPosts(userPosts);
+      setAvatar(userAvatar);
+    }).catch(() => setError('データの取得に失敗しました。'))
       .finally(() => setLoading(false));
   }, [user, navigate]);
 
@@ -45,6 +54,12 @@ export const DashboardPage = () => {
   if (!user) return null;
 
   const recentMoods = posts.slice(0, 7).map((p) => p.mood);
+
+  const showReminder = posts.length === 0 || (() => {
+    const lastPost = new Date(posts[0].createdAt);
+    const daysSince = (Date.now() - lastPost.getTime()) / (1000 * 60 * 60 * 24);
+    return daysSince >= DAYS_BEFORE_REMINDER;
+  })();
 
   return (
     <div>
@@ -68,6 +83,23 @@ export const DashboardPage = () => {
         </div>
         <Link to="/posts/new" style={styles.newBtn}>+ 今日の気持ちを記録</Link>
       </div>
+
+      {avatar && <AvatarCard avatar={avatar} />}
+
+      {showReminder && !loading && (
+        <div style={styles.reminderBanner}>
+          <span>そろそろ気持ちを記録してみませんか？</span>
+          <Link to="/posts/new" style={styles.reminderLink}>記録する →</Link>
+        </div>
+      )}
+
+      {user.reDiagnosisNeeded && user.mbtiType && (
+        <div style={styles.rediagBanner}>
+          <FiRefreshCw size={14} style={{ verticalAlign: 'middle', marginRight: 6 }} />
+          最近の記録を見ると、あなたの傾向が少し変わってきているかもしれません。
+          <Link to="/onboarding" style={styles.rediagLink}> 仮診断を更新してみる →</Link>
+        </div>
+      )}
 
       {recentMoods.length > 0 && (
         <div style={styles.weatherRow}>
@@ -122,4 +154,15 @@ const styles: Record<string, React.CSSProperties> = {
   errorText: { color: '#842029', background: '#fff0f0', padding: '0.6rem 1rem', borderRadius: '6px' },
   empty: { textAlign: 'center', padding: '3rem', color: '#888', background: '#fff', borderRadius: '12px' },
   emptyLink: { color: '#2d7a4f', textDecoration: 'none', fontWeight: 600 },
+  reminderBanner: {
+    display: 'flex', alignItems: 'center', justifyContent: 'space-between', flexWrap: 'wrap' as const,
+    background: '#f0fdf4', border: '1px solid #a3d9a5', borderRadius: '10px',
+    padding: '0.75rem 1rem', marginBottom: '1rem', fontSize: '0.9rem', color: '#2d7a4f', gap: '0.5rem',
+  },
+  reminderLink: { color: '#2d7a4f', fontWeight: 700, textDecoration: 'none', whiteSpace: 'nowrap' as const },
+  rediagBanner: {
+    background: '#fffbeb', border: '1px solid #fcd34d', borderRadius: '10px',
+    padding: '0.75rem 1rem', marginBottom: '1rem', fontSize: '0.88rem', color: '#92400e',
+  },
+  rediagLink: { color: '#d97706', fontWeight: 700, textDecoration: 'none' },
 };

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -4,17 +4,14 @@ import { getPostsByUser, deletePost } from '../api/posts';
 import { useAuth } from '../context/AuthContext';
 import { PostCard } from '../components/PostCard';
 import type { Post, WeatherMood } from '../types';
+import { moodConfig } from '../utils/moodConfig';
+import { FiStar } from 'react-icons/fi';
 
 const MBTI_NAMES: Record<string, string> = {
   INFP: '優しき理想家', INFJ: '静かな導き手', ISFP: '感性のアーティスト', ISFJ: '世話好きな癒し手',
   INTP: '知の探求者', INTJ: '静かな野心家', ISTP: '静かなる実行者', ISTJ: '堅実な守り人',
   ENFP: '夢見る冒険者', ENFJ: '共鳴する応援者', ESFP: '陽気なひまわり', ESFJ: '頼れるお姉さん',
   ENTP: 'ひらめきの火花', ENTJ: 'ビジョンの指揮官', ESTP: 'アクションスター', ESTJ: '現実主義の管理者',
-};
-
-const moodIcon: Record<WeatherMood, string> = {
-  STORM: '⛈️', RAIN: '🌧️', SNOW: '❄️', FOG: '🌫️', CLOUDY: '⛅',
-  WHIRLWIND: '🌪️', SPROUT: '🌻', RAINBOW: '🌈', STAR: '🌟', SUNNY: '☀️',
 };
 
 export const DashboardPage = () => {
@@ -58,13 +55,14 @@ export const DashboardPage = () => {
           </h2>
           {user.mbtiType && (
             <div style={styles.mbtiBadge}>
-              ✨ {user.mbtiType}
+              <FiStar size={13} style={{ verticalAlign: 'middle', marginRight: 4 }} />
+              {user.mbtiType}
               {MBTI_NAMES[user.mbtiType] && <span style={styles.mbtiName}> 「{MBTI_NAMES[user.mbtiType]}」</span>}
             </div>
           )}
           {!user.mbtiType && (
             <Link to="/onboarding" style={styles.mbtiLink}>
-              ✨ 性格タイプを診断する →
+              <FiStar size={13} style={{ verticalAlign: 'middle', marginRight: 4 }} /> 性格タイプを診断する →
             </Link>
           )}
         </div>
@@ -74,11 +72,14 @@ export const DashboardPage = () => {
       {recentMoods.length > 0 && (
         <div style={styles.weatherRow}>
           <span style={styles.weatherLabel}>最近の天気:</span>
-          {recentMoods.map((mood, i) => (
-            <span key={i} style={styles.weatherIcon} title={mood}>
-              {moodIcon[mood]}
-            </span>
-          ))}
+          {recentMoods.map((mood, i) => {
+            const MoodIcon = (moodConfig[mood] ?? moodConfig.CLOUDY).icon;
+            return (
+              <span key={i} style={{ ...styles.weatherIcon, color: moodConfig[mood]?.text ?? '#555' }} title={mood}>
+                <MoodIcon size={24} />
+              </span>
+            );
+          })}
         </div>
       )}
 
@@ -116,7 +117,7 @@ const styles: Record<string, React.CSSProperties> = {
     marginBottom: '1.2rem', flexWrap: 'wrap',
   },
   weatherLabel: { fontSize: '0.82rem', color: '#888', marginRight: '0.25rem' },
-  weatherIcon: { fontSize: '1.4rem', cursor: 'default' },
+  weatherIcon: { display: 'inline-flex', cursor: 'default' },
   info: { textAlign: 'center', color: '#888' },
   errorText: { color: '#842029', background: '#fff0f0', padding: '0.6rem 1rem', borderRadius: '6px' },
   empty: { textAlign: 'center', padding: '3rem', color: '#888', background: '#fff', borderRadius: '12px' },

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -3,6 +3,7 @@ import { Link, useNavigate } from 'react-router-dom';
 import { login } from '../api/auth';
 import { useAuth } from '../context/AuthContext';
 import { ApiError } from '../api/client';
+import { FaLeaf } from 'react-icons/fa';
 
 export const LoginPage = () => {
   const { setUser } = useAuth();
@@ -30,7 +31,7 @@ export const LoginPage = () => {
   return (
     <div style={styles.wrapper}>
       <div style={styles.card}>
-        <h1 style={styles.title}>🌱 Habitora</h1>
+        <h1 style={styles.title}><FaLeaf style={{ verticalAlign: 'middle', marginRight: 8 }} /> Habitora</h1>
         <p style={styles.subtitle}>ログイン</p>
         {error && <div style={styles.error}>{error}</div>}
         <form onSubmit={handleSubmit}>

--- a/frontend/src/pages/MoodForecastPage.tsx
+++ b/frontend/src/pages/MoodForecastPage.tsx
@@ -4,6 +4,7 @@ import { useNavigate } from 'react-router-dom';
 import { getMoodForecast, regenerateForecast } from '../api/moodForecast';
 import type { MoodForecast } from '../types';
 import { moodConfig } from '../utils/moodConfig';
+import { MoodBubble } from '../components/MoodBubble';
 import type { WeatherMood } from '../types';
 import { FiCloud, FiRefreshCw, FiMessageCircle } from 'react-icons/fi';
 
@@ -55,9 +56,9 @@ export const MoodForecastPage = () => {
     <div>
       <h2 style={styles.heading}><FiCloud size={20} style={{ verticalAlign: 'middle', marginRight: 8 }} /> 気持ち天気予報</h2>
 
-      <div style={styles.mainCard}>
-        {(() => { const mc = moodConfig[forecast.mainMood as WeatherMood] ?? moodConfig.CLOUDY; const MI = mc.icon; return <div style={{ ...styles.bigIcon, color: mc.text }}><MI size={72} /></div>; })()}
-        <div style={styles.mainMoodLabel}>{(moodConfig[forecast.mainMood as WeatherMood] ?? moodConfig.CLOUDY).label}</div>
+      <div style={{ ...styles.mainCard, background: (moodConfig[forecast.mainMood as WeatherMood] ?? moodConfig.CLOUDY).color, borderColor: (moodConfig[forecast.mainMood as WeatherMood] ?? moodConfig.CLOUDY).border }}>
+        <div style={styles.bigIcon}><MoodBubble mood={forecast.mainMood} size={56} /></div>
+        <div style={{ ...styles.mainMoodLabel, color: (moodConfig[forecast.mainMood as WeatherMood] ?? moodConfig.CLOUDY).text }}>{(moodConfig[forecast.mainMood as WeatherMood] ?? moodConfig.CLOUDY).label}</div>
         {forecast.avatarComment && (
           <p style={styles.avatarComment}><FiMessageCircle size={14} style={{ verticalAlign: 'middle', marginRight: 4 }} /> {forecast.avatarComment}</p>
         )}
@@ -67,18 +68,14 @@ export const MoodForecastPage = () => {
         <div style={styles.section}>
           <h3 style={styles.sectionTitle}>直近7日間の天気</h3>
           <div style={styles.trendRow}>
-            {trendEntries.map(([date, mood]) => {
-              const mc = moodConfig[mood as WeatherMood] ?? moodConfig.CLOUDY;
-              const MI = mc.icon;
-              return (
-                <div key={date} style={styles.trendItem}>
-                  <span style={{ ...styles.trendIcon, color: mc.text }}><MI size={28} /></span>
-                  <span style={styles.trendDate}>
-                    {new Date(date).toLocaleDateString('ja-JP', { month: 'numeric', day: 'numeric' })}
-                  </span>
-                </div>
-              );
-            })}
+            {trendEntries.map(([date, mood]) => (
+              <div key={date} style={styles.trendItem}>
+                <MoodBubble mood={mood} size={22} />
+                <span style={styles.trendDate}>
+                  {new Date(date).toLocaleDateString('ja-JP', { month: 'numeric', day: 'numeric' })}
+                </span>
+              </div>
+            ))}
           </div>
         </div>
       )}
@@ -105,9 +102,9 @@ const styles: Record<string, React.CSSProperties> = {
   heading: { marginBottom: '1.5rem', color: '#333' },
   center: { textAlign: 'center', marginTop: '3rem', color: '#666' },
   errorBox: { textAlign: 'center', padding: '3rem 1rem', background: '#fff', borderRadius: '12px', border: '1px solid #eee' },
-  mainCard: { textAlign: 'center', background: '#fff', border: '1px solid #eee', borderRadius: '16px', padding: '2.5rem 1rem', marginBottom: '1.5rem' },
-  bigIcon: { lineHeight: 1, display: 'flex', justifyContent: 'center' },
-  mainMoodLabel: { fontSize: '1.4rem', fontWeight: 700, color: '#333', marginTop: '0.5rem' },
+  mainCard: { textAlign: 'center', border: '1px solid', borderRadius: '16px', padding: '2.5rem 1rem', marginBottom: '1.5rem' },
+  bigIcon: { lineHeight: 1, display: 'flex', justifyContent: 'center', marginBottom: '0.75rem' },
+  mainMoodLabel: { fontSize: '1.4rem', fontWeight: 700, marginTop: '0.25rem' },
   avatarComment: { marginTop: '1rem', color: '#555', fontSize: '0.95rem', lineHeight: 1.6, fontStyle: 'italic' },
   section: { background: '#fff', border: '1px solid #eee', borderRadius: '12px', padding: '1.2rem', marginBottom: '1rem' },
   sectionTitle: { margin: '0 0 1rem', fontSize: '0.95rem', color: '#555', fontWeight: 600 },

--- a/frontend/src/pages/MoodForecastPage.tsx
+++ b/frontend/src/pages/MoodForecastPage.tsx
@@ -3,15 +3,9 @@ import { useAuth } from '../context/AuthContext';
 import { useNavigate } from 'react-router-dom';
 import { getMoodForecast, regenerateForecast } from '../api/moodForecast';
 import type { MoodForecast } from '../types';
-
-const moodIcon: Record<string, string> = {
-  STORM: '⛈️', RAIN: '🌧️', SNOW: '❄️', FOG: '🌫️', CLOUDY: '⛅',
-  WHIRLWIND: '🌪️', SPROUT: '🌻', RAINBOW: '🌈', STAR: '🌟', SUNNY: '☀️',
-};
-const moodLabel: Record<string, string> = {
-  STORM: '嵐', RAIN: '雨', SNOW: '雪', FOG: '霧', CLOUDY: 'くもり',
-  WHIRLWIND: 'つむじ風', SPROUT: '芽吹き', RAINBOW: '虹', STAR: '星空', SUNNY: '晴れ',
-};
+import { moodConfig } from '../utils/moodConfig';
+import type { WeatherMood } from '../types';
+import { FiCloud, FiRefreshCw, FiMessageCircle } from 'react-icons/fi';
 
 export const MoodForecastPage = () => {
   const { user } = useAuth();
@@ -59,13 +53,13 @@ export const MoodForecastPage = () => {
 
   return (
     <div>
-      <h2 style={styles.heading}>⛅ 気持ち天気予報</h2>
+      <h2 style={styles.heading}><FiCloud size={20} style={{ verticalAlign: 'middle', marginRight: 8 }} /> 気持ち天気予報</h2>
 
       <div style={styles.mainCard}>
-        <div style={styles.bigIcon}>{moodIcon[forecast.mainMood] ?? '⛅'}</div>
-        <div style={styles.mainMoodLabel}>{moodLabel[forecast.mainMood] ?? forecast.mainMood}</div>
+        {(() => { const mc = moodConfig[forecast.mainMood as WeatherMood] ?? moodConfig.CLOUDY; const MI = mc.icon; return <div style={{ ...styles.bigIcon, color: mc.text }}><MI size={72} /></div>; })()}
+        <div style={styles.mainMoodLabel}>{(moodConfig[forecast.mainMood as WeatherMood] ?? moodConfig.CLOUDY).label}</div>
         {forecast.avatarComment && (
-          <p style={styles.avatarComment}>💬 {forecast.avatarComment}</p>
+          <p style={styles.avatarComment}><FiMessageCircle size={14} style={{ verticalAlign: 'middle', marginRight: 4 }} /> {forecast.avatarComment}</p>
         )}
       </div>
 
@@ -73,14 +67,18 @@ export const MoodForecastPage = () => {
         <div style={styles.section}>
           <h3 style={styles.sectionTitle}>直近7日間の天気</h3>
           <div style={styles.trendRow}>
-            {trendEntries.map(([date, mood]) => (
-              <div key={date} style={styles.trendItem}>
-                <span style={styles.trendIcon}>{moodIcon[mood] ?? '⛅'}</span>
-                <span style={styles.trendDate}>
-                  {new Date(date).toLocaleDateString('ja-JP', { month: 'numeric', day: 'numeric' })}
-                </span>
-              </div>
-            ))}
+            {trendEntries.map(([date, mood]) => {
+              const mc = moodConfig[mood as WeatherMood] ?? moodConfig.CLOUDY;
+              const MI = mc.icon;
+              return (
+                <div key={date} style={styles.trendItem}>
+                  <span style={{ ...styles.trendIcon, color: mc.text }}><MI size={28} /></span>
+                  <span style={styles.trendDate}>
+                    {new Date(date).toLocaleDateString('ja-JP', { month: 'numeric', day: 'numeric' })}
+                  </span>
+                </div>
+              );
+            })}
           </div>
         </div>
       )}
@@ -93,7 +91,7 @@ export const MoodForecastPage = () => {
       )}
 
       <button onClick={handleRegenerate} disabled={refreshing} style={styles.refreshBtn}>
-        {refreshing ? '更新中...' : '🔄 今すぐ更新する'}
+        {refreshing ? '更新中...' : <><FiRefreshCw size={16} style={{ verticalAlign: 'middle', marginRight: 6 }} /> 今すぐ更新する</>}
       </button>
 
       <p style={styles.footerNote}>
@@ -108,14 +106,14 @@ const styles: Record<string, React.CSSProperties> = {
   center: { textAlign: 'center', marginTop: '3rem', color: '#666' },
   errorBox: { textAlign: 'center', padding: '3rem 1rem', background: '#fff', borderRadius: '12px', border: '1px solid #eee' },
   mainCard: { textAlign: 'center', background: '#fff', border: '1px solid #eee', borderRadius: '16px', padding: '2.5rem 1rem', marginBottom: '1.5rem' },
-  bigIcon: { fontSize: '4rem', lineHeight: 1 },
+  bigIcon: { lineHeight: 1, display: 'flex', justifyContent: 'center' },
   mainMoodLabel: { fontSize: '1.4rem', fontWeight: 700, color: '#333', marginTop: '0.5rem' },
   avatarComment: { marginTop: '1rem', color: '#555', fontSize: '0.95rem', lineHeight: 1.6, fontStyle: 'italic' },
   section: { background: '#fff', border: '1px solid #eee', borderRadius: '12px', padding: '1.2rem', marginBottom: '1rem' },
   sectionTitle: { margin: '0 0 1rem', fontSize: '0.95rem', color: '#555', fontWeight: 600 },
   trendRow: { display: 'flex', gap: '0.5rem', flexWrap: 'wrap' },
   trendItem: { display: 'flex', flexDirection: 'column', alignItems: 'center', gap: '0.25rem', minWidth: '44px' },
-  trendIcon: { fontSize: '1.6rem' },
+  trendIcon: { display: 'inline-flex' },
   trendDate: { fontSize: '0.72rem', color: '#888' },
   summaryText: { margin: 0, color: '#444', fontSize: '0.95rem', lineHeight: 1.7 },
   refreshBtn: { display: 'block', width: '100%', padding: '0.8rem', background: '#2d7a4f', color: '#fff', border: 'none', borderRadius: '10px', fontSize: '1rem', fontWeight: 600, cursor: 'pointer', marginBottom: '0.75rem' },

--- a/frontend/src/pages/NotificationsPage.tsx
+++ b/frontend/src/pages/NotificationsPage.tsx
@@ -3,12 +3,15 @@ import { useAuth } from '../context/AuthContext';
 import { useNavigate } from 'react-router-dom';
 import { listNotifications, markNotificationRead } from '../api/notifications';
 import type { Notification } from '../types';
+import { FiHeart, FiCalendar, FiCloud, FiAward, FiBell } from 'react-icons/fi';
+import type { IconType } from 'react-icons';
 
-const typeIcon: Record<string, string> = {
-  THANK: '💛',
-  REMINDER: '📅',
-  MOOD: '⛅',
-  ACHIEVEMENT: '✨',
+const typeIcon: Record<string, IconType> = {
+  THANK: FiHeart,
+  REMINDER: FiCalendar,
+  MOOD: FiCloud,
+  ACHIEVEMENT: FiAward,
+  COMMENT: FiAward,
 };
 
 export const NotificationsPage = () => {
@@ -39,7 +42,7 @@ export const NotificationsPage = () => {
 
   return (
     <div>
-      <h2 style={styles.heading}>🔔 通知</h2>
+      <h2 style={styles.heading}><FiBell size={20} style={{ verticalAlign: 'middle', marginRight: 8 }} /> 通知</h2>
       {notifications.length === 0 ? (
         <div style={styles.empty}>
           <p>通知はまだありません。</p>
@@ -53,7 +56,7 @@ export const NotificationsPage = () => {
               style={{ ...styles.item, background: n.isRead ? '#f9f9f9' : '#fffde7', cursor: n.isRead ? 'default' : 'pointer' }}
               onClick={() => handleClick(n)}
             >
-              <span style={styles.icon}>{typeIcon[n.type] ?? '🔔'}</span>
+              <span style={styles.icon}>{(() => { const NI = typeIcon[n.type] ?? FiBell; return <NI size={20} />; })()}</span>
               <div style={styles.body}>
                 <p style={styles.title}>{n.title}</p>
                 <p style={styles.message}>{n.message}</p>
@@ -76,7 +79,7 @@ const styles: Record<string, React.CSSProperties> = {
   empty: { textAlign: 'center', padding: '3rem 1rem', color: '#777', background: '#fff', borderRadius: '12px', border: '1px solid #eee' },
   list: { listStyle: 'none', padding: 0, margin: 0, display: 'flex', flexDirection: 'column', gap: '0.5rem' },
   item: { display: 'flex', alignItems: 'flex-start', gap: '0.75rem', padding: '1rem', borderRadius: '10px', border: '1px solid #eee', transition: 'background 0.15s' },
-  icon: { fontSize: '1.4rem', flexShrink: 0 },
+  icon: { flexShrink: 0, display: 'flex', alignItems: 'center', color: '#2d7a4f' },
   body: { flex: 1 },
   title: { margin: '0 0 0.25rem', fontWeight: 600, fontSize: '0.95rem', color: '#333' },
   message: { margin: '0 0 0.4rem', fontSize: '0.88rem', color: '#555' },

--- a/frontend/src/pages/NotificationsPage.tsx
+++ b/frontend/src/pages/NotificationsPage.tsx
@@ -3,7 +3,7 @@ import { useAuth } from '../context/AuthContext';
 import { useNavigate } from 'react-router-dom';
 import { listNotifications, markNotificationRead } from '../api/notifications';
 import type { Notification } from '../types';
-import { FiHeart, FiCalendar, FiCloud, FiAward, FiBell } from 'react-icons/fi';
+import { FiHeart, FiCalendar, FiCloud, FiAward, FiBell, FiMessageCircle } from 'react-icons/fi';
 import type { IconType } from 'react-icons';
 
 const typeIcon: Record<string, IconType> = {
@@ -11,7 +11,7 @@ const typeIcon: Record<string, IconType> = {
   REMINDER: FiCalendar,
   MOOD: FiCloud,
   ACHIEVEMENT: FiAward,
-  COMMENT: FiAward,
+  COMMENT: FiMessageCircle,
 };
 
 export const NotificationsPage = () => {

--- a/frontend/src/pages/OnboardingPage.tsx
+++ b/frontend/src/pages/OnboardingPage.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import { submitInitialMbti, type MbtiAnswers } from '../api/mbti';
 import { useAuth } from '../context/AuthContext';
 import { ApiError } from '../api/client';
+import { PiStarFourFill } from 'react-icons/pi';
 
 const QUESTIONS = [
   {
@@ -93,7 +94,7 @@ export const OnboardingPage = () => {
     return (
       <div style={styles.wrapper}>
         <div style={styles.card}>
-          <div style={styles.emoji}>✨</div>
+          <div style={styles.emoji}><PiStarFourFill size={48} color="#f59e0b" /></div>
           <h2 style={styles.title}>あなたのタイプは...</h2>
           <div style={styles.resultType}>{result.resultType}</div>
           <div style={styles.typeName}>「{typeName}」</div>
@@ -161,7 +162,7 @@ const styles: Record<string, React.CSSProperties> = {
     borderRadius: '10px', fontSize: '0.95rem', cursor: 'pointer', color: '#333',
     textAlign: 'left', transition: 'all 0.15s ease', fontWeight: 500,
   },
-  emoji: { fontSize: '3rem', marginBottom: '0.5rem' },
+  emoji: { display: 'flex', justifyContent: 'center', marginBottom: '0.5rem' },
   resultType: { fontSize: '2.5rem', fontWeight: 700, color: '#2d7a4f', marginBottom: '0.5rem' },
   typeName: { fontSize: '1.2rem', color: '#555', marginBottom: '1rem' },
   resultNote: { fontSize: '0.85rem', color: '#888', lineHeight: 1.6, marginBottom: '2rem' },

--- a/frontend/src/pages/OnboardingPage.tsx
+++ b/frontend/src/pages/OnboardingPage.tsx
@@ -128,7 +128,8 @@ export const OnboardingPage = () => {
         <div style={styles.progressBar}>
           <div style={{ ...styles.progressFill, width: `${((step + 1) / QUESTIONS.length) * 100}%` }} />
         </div>
-        <h2 style={styles.title}>あなたのことを教えてください</h2>
+        <h2 style={styles.title}>はじめの仮診断</h2>
+        <p style={styles.subtitle}>これは「今のあなた」のスタートポイントです。記録を重ねるうちに、より深く自分を知ることができます。</p>
         {error && <div style={styles.error}>{error}</div>}
         <p style={styles.question}>{q.question}</p>
         <div style={styles.options}>
@@ -151,7 +152,8 @@ const styles: Record<string, React.CSSProperties> = {
   progress: { fontSize: '0.8rem', color: '#aaa', marginBottom: '0.5rem' },
   progressBar: { height: '4px', background: '#e0e0e0', borderRadius: '2px', marginBottom: '2rem', overflow: 'hidden' },
   progressFill: { height: '100%', background: '#2d7a4f', borderRadius: '2px', transition: 'width 0.3s ease' },
-  title: { color: '#333', marginBottom: '1.5rem', fontSize: '1.1rem' },
+  title: { color: '#333', marginBottom: '0.5rem', fontSize: '1.1rem' },
+  subtitle: { fontSize: '0.82rem', color: '#888', lineHeight: 1.5, marginBottom: '1.25rem' },
   question: { fontSize: '1rem', color: '#444', lineHeight: 1.6, marginBottom: '1.5rem' },
   options: { display: 'flex', flexDirection: 'column', gap: '0.75rem' },
   option: {

--- a/frontend/src/pages/ProfilePage.tsx
+++ b/frontend/src/pages/ProfilePage.tsx
@@ -3,6 +3,7 @@ import { useNavigate, Link } from 'react-router-dom';
 import { useAuth } from '../context/AuthContext';
 import { request } from '../api/client';
 import type { User } from '../types';
+import { FiUser } from 'react-icons/fi';
 
 export const ProfilePage = () => {
   const { user, setUser } = useAuth();
@@ -45,7 +46,7 @@ export const ProfilePage = () => {
 
   return (
     <div style={styles.wrap}>
-      <h2 style={styles.heading}>👤 プロフィール</h2>
+      <h2 style={styles.heading}><FiUser size={20} style={{ verticalAlign: 'middle', marginRight: 8 }} /> プロフィール</h2>
 
       <div style={styles.statsRow}>
         <div style={styles.stat}><span style={styles.statNum}>Lv.{user.level}</span><span style={styles.statLabel}>レベル</span></div>

--- a/frontend/src/pages/ProfilePage.tsx
+++ b/frontend/src/pages/ProfilePage.tsx
@@ -3,7 +3,19 @@ import { useNavigate, Link } from 'react-router-dom';
 import { useAuth } from '../context/AuthContext';
 import { request } from '../api/client';
 import type { User } from '../types';
-import { FiUser } from 'react-icons/fi';
+import { FiUser, FiHeart } from 'react-icons/fi';
+
+const KINDNESS_BADGES = [
+  { min: 50, label: '星の優しさ', color: '#f59e0b' },
+  { min: 20, label: '実りの優しさ', color: '#16a34a' },
+  { min: 10, label: '花の優しさ', color: '#ec4899' },
+  { min: 5,  label: '若葉の優しさ', color: '#22c55e' },
+  { min: 1,  label: '芽の優しさ', color: '#84cc16' },
+  { min: 0,  label: '種の優しさ', color: '#a8a29e' },
+] as const;
+
+const getKindnessBadge = (total: number) =>
+  KINDNESS_BADGES.find((b) => total >= b.min) ?? KINDNESS_BADGES[KINDNESS_BADGES.length - 1];
 
 export const ProfilePage = () => {
   const { user, setUser } = useAuth();
@@ -50,10 +62,23 @@ export const ProfilePage = () => {
 
       <div style={styles.statsRow}>
         <div style={styles.stat}><span style={styles.statNum}>Lv.{user.level}</span><span style={styles.statLabel}>レベル</span></div>
-        <div style={styles.stat}><span style={styles.statNum}>{user.kindnessTotal}</span><span style={styles.statLabel}>優しさ合計</span></div>
+        <div style={styles.stat}>
+          {(() => {
+            const badge = getKindnessBadge(user.kindnessTotal);
+            return (
+              <>
+                <span style={{ ...styles.statNum, color: badge.color, fontSize: '1rem' }}>
+                  <FiHeart size={16} style={{ verticalAlign: 'middle', marginRight: 3 }} />
+                  {badge.label}
+                </span>
+                <span style={styles.statLabel}>{user.kindnessTotal}回のありがとう</span>
+              </>
+            );
+          })()}
+        </div>
         <div style={styles.stat}>
           <span style={styles.statNum}>{mbtiLabel}</span>
-          <span style={styles.statLabel}>MBTIタイプ</span>
+          <span style={styles.statLabel}>性格タイプ（仮）</span>
         </div>
       </div>
 

--- a/frontend/src/pages/RegisterPage.tsx
+++ b/frontend/src/pages/RegisterPage.tsx
@@ -4,6 +4,7 @@ import { register } from '../api/users';
 import { login } from '../api/auth';
 import { useAuth } from '../context/AuthContext';
 import { ApiError } from '../api/client';
+import { FaLeaf } from 'react-icons/fa';
 
 export const RegisterPage = () => {
   const { setUser } = useAuth();
@@ -38,7 +39,7 @@ export const RegisterPage = () => {
   return (
     <div style={styles.wrapper}>
       <div style={styles.card}>
-        <h1 style={styles.title}>🌱 Habitora</h1>
+        <h1 style={styles.title}><FaLeaf style={{ verticalAlign: 'middle', marginRight: 8 }} /> Habitora</h1>
         <p style={styles.subtitle}>新規登録</p>
         {error && <div style={styles.error}>{error}</div>}
         <form onSubmit={handleSubmit}>

--- a/frontend/src/pages/ReviewPage.tsx
+++ b/frontend/src/pages/ReviewPage.tsx
@@ -3,11 +3,9 @@ import { useAuth } from '../context/AuthContext';
 import { useNavigate } from 'react-router-dom';
 import { generateReview, listReviews } from '../api/reviews';
 import type { Review } from '../types';
-
-const moodIcon: Record<string, string> = {
-  STORM: '⛈️', RAIN: '🌧️', SNOW: '❄️', FOG: '🌫️', CLOUDY: '⛅',
-  WHIRLWIND: '🌪️', SPROUT: '🌻', RAINBOW: '🌈', STAR: '🌟', SUNNY: '☀️',
-};
+import { moodConfig } from '../utils/moodConfig';
+import type { WeatherMood } from '../types';
+import { FiBookOpen, FiStar, FiMessageCircle } from 'react-icons/fi';
 
 export const ReviewPage = () => {
   const { user } = useAuth();
@@ -57,13 +55,13 @@ export const ReviewPage = () => {
 
   return (
     <div>
-      <h2 style={styles.heading}>📖 ふり返り</h2>
+      <h2 style={styles.heading}><FiBookOpen size={20} style={{ verticalAlign: 'middle', marginRight: 8 }} /> ふり返り</h2>
 
       <div style={styles.generateBox}>
         <p style={styles.generateDesc}>今月の記録をもとにふり返りを生成します。</p>
         {genError && <p style={styles.error}>{genError}</p>}
         <button onClick={handleGenerate} disabled={generating} style={styles.generateBtn}>
-          {generating ? '生成中...' : '✨ 今月のふり返りを生成'}
+          {generating ? '生成中...' : <><FiStar size={16} style={{ verticalAlign: 'middle', marginRight: 6 }} /> 今月のふり返りを生成</>}
         </button>
       </div>
 
@@ -84,7 +82,7 @@ export const ReviewPage = () => {
               <div key={r.id} style={styles.card}>
                 <div style={styles.cardHeader}>
                   <span style={styles.period}>{period}</span>
-                  {mm && <span style={styles.moodIcon}>{moodIcon[mm] ?? '⛅'}</span>}
+                  {mm && (() => { const MC = (moodConfig[mm as WeatherMood] ?? moodConfig.CLOUDY); const MI = MC.icon; return <span style={{ ...styles.moodIcon, color: MC.text }}><MI size={26} /></span>; })()}
                   {r.levelChange > 0 && <span style={styles.levelBadge}>+{r.levelChange} Lv UP!</span>}
                 </div>
                 {r.summaryText && <p style={styles.summary}>{r.summaryText}</p>}
@@ -92,7 +90,7 @@ export const ReviewPage = () => {
                   <p style={styles.score}>平均スコア: <strong>{h.avg}点</strong></p>
                 )}
                 {r.avatarComment && (
-                  <p style={styles.avatarComment}>💬 {r.avatarComment}</p>
+                  <p style={styles.avatarComment}><FiMessageCircle size={14} style={{ verticalAlign: 'middle', marginRight: 4 }} /> {r.avatarComment}</p>
                 )}
                 <time style={styles.reviewedAt}>
                   生成日: {new Date(r.reviewedAt).toLocaleDateString('ja-JP', { month: 'short', day: 'numeric' })}
@@ -118,7 +116,7 @@ const styles: Record<string, React.CSSProperties> = {
   card: { background: '#fff', border: '1px solid #eee', borderRadius: '12px', padding: '1.2rem' },
   cardHeader: { display: 'flex', alignItems: 'center', gap: '0.75rem', marginBottom: '0.75rem' },
   period: { fontWeight: 700, fontSize: '1rem', color: '#333' },
-  moodIcon: { fontSize: '1.5rem' },
+  moodIcon: { display: 'inline-flex' },
   levelBadge: { marginLeft: 'auto', background: '#fef3c7', color: '#d97706', fontSize: '0.8rem', fontWeight: 700, padding: '2px 10px', borderRadius: '10px', border: '1px solid #fcd34d' },
   summary: { margin: '0 0 0.5rem', color: '#444', fontSize: '0.95rem', lineHeight: 1.6 },
   score: { margin: '0 0 0.5rem', fontSize: '0.9rem', color: '#555' },

--- a/frontend/src/pages/ReviewPage.tsx
+++ b/frontend/src/pages/ReviewPage.tsx
@@ -7,6 +7,14 @@ import { moodConfig } from '../utils/moodConfig';
 import type { WeatherMood } from '../types';
 import { FiBookOpen, FiStar, FiMessageCircle } from 'react-icons/fi';
 
+const scoreToQualitative = (avg: number): string => {
+  if (avg >= 90) return 'とても晴れやかな気持ちの月でした。';
+  if (avg >= 70) return '穏やかで前向きな気持ちが続いた月でした。';
+  if (avg >= 50) return '穏やかな日と揺れる日が混ざり合った月でした。';
+  if (avg >= 30) return '少し重さや揺れを感じる日が多かった月でした。';
+  return '心が重く感じることが多い月でした。自分をいたわってあげてください。';
+};
+
 export const ReviewPage = () => {
   const { user } = useAuth();
   const navigate = useNavigate();
@@ -87,7 +95,7 @@ export const ReviewPage = () => {
                 </div>
                 {r.summaryText && <p style={styles.summary}>{r.summaryText}</p>}
                 {h && (
-                  <p style={styles.score}>平均スコア: <strong>{h.avg}点</strong></p>
+                  <p style={styles.score}>{scoreToQualitative(h.avg)}</p>
                 )}
                 {r.avatarComment && (
                   <p style={styles.avatarComment}><FiMessageCircle size={14} style={{ verticalAlign: 'middle', marginRight: 4 }} /> {r.avatarComment}</p>

--- a/frontend/src/pages/TimelinePage.tsx
+++ b/frontend/src/pages/TimelinePage.tsx
@@ -44,7 +44,7 @@ export const TimelinePage = () => {
   return (
     <div>
       <h2 style={styles.heading}>👥 みんなの投稿</h2>
-      <p style={styles.desc}>公開されている気持ちの記録です。「ありがとう」を送って優しさを届けましょう。</p>
+      <p style={styles.desc}>公開されている気持ちの記録です。コメントして「ありがとう」を届けましょう。</p>
 
       {posts.length === 0 ? (
         <div style={styles.empty}>
@@ -56,7 +56,7 @@ export const TimelinePage = () => {
       ) : (
         <>
           {posts.map((post) => (
-            <PostCard key={post.id} post={post} showThankBtn={true} />
+            <PostCard key={post.id} post={post} />
           ))}
           {hasMore && (
             <button onClick={handleLoadMore} disabled={loadingMore} style={styles.moreBtn}>

--- a/frontend/src/pages/TimelinePage.tsx
+++ b/frontend/src/pages/TimelinePage.tsx
@@ -4,6 +4,7 @@ import { useNavigate } from 'react-router-dom';
 import { getTimeline } from '../api/posts';
 import { PostCard } from '../components/PostCard';
 import type { Post } from '../types';
+import { FiUsers } from 'react-icons/fi';
 
 export const TimelinePage = () => {
   const { user } = useAuth();
@@ -43,7 +44,7 @@ export const TimelinePage = () => {
 
   return (
     <div>
-      <h2 style={styles.heading}>👥 みんなの投稿</h2>
+      <h2 style={styles.heading}><FiUsers size={20} style={{ verticalAlign: 'middle', marginRight: 8 }} /> みんなの投稿</h2>
       <p style={styles.desc}>公開されている気持ちの記録です。コメントして「ありがとう」を届けましょう。</p>
 
       {posts.length === 0 ? (

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -19,7 +19,20 @@ export interface User {
   kindnessTotal: number;
   penaltyCount: number;
   isRestricted: boolean;
+  reDiagnosisNeeded: boolean;
   registeredAt: string;
+}
+
+export interface Avatar {
+  id: number;
+  userId: number;
+  fixedType: string | null;
+  level: number;
+  mood: string;
+  expression: string;
+  itemsJson: string;
+  commentStyle: string;
+  updatedAt: string;
 }
 
 export interface Post {
@@ -42,6 +55,7 @@ export interface Comment {
   isHidden: boolean;
   createdAt: string;
   thankCount: number;
+  isThankedByAuthor: boolean;
 }
 
 export interface Thank {

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -17,6 +17,8 @@ export interface User {
   mbtiType: string | null;
   level: number;
   kindnessTotal: number;
+  penaltyCount: number;
+  isRestricted: boolean;
   registeredAt: string;
 }
 
@@ -31,9 +33,20 @@ export interface Post {
   createdAt: string;
 }
 
-export interface Thank {
+export interface Comment {
   id: number;
   postId: number;
+  userId: number;
+  authorNickname: string | null;
+  text: string;
+  isHidden: boolean;
+  createdAt: string;
+  thankCount: number;
+}
+
+export interface Thank {
+  id: number;
+  commentId: number;
   fromUserId: number;
   toUserId: number;
   message: string | null;

--- a/frontend/src/utils/moodConfig.ts
+++ b/frontend/src/utils/moodConfig.ts
@@ -1,9 +1,7 @@
 import {
-  WiThunderstorm, WiRain, WiSnow, WiFog, WiDayCloudy,
-  WiStrongWind, WiNightClear, WiDaySunny,
-} from 'react-icons/wi';
-import { FaSeedling } from 'react-icons/fa';
-import { BsRainbow } from 'react-icons/bs';
+  PiCloudLightningFill, PiCloudRainFill, PiCloudSnowFill, PiCloudFogFill,
+  PiCloudFill, PiWindFill, PiPlantFill, PiRainbowFill, PiMoonStarsFill, PiSunFill,
+} from 'react-icons/pi';
 import type { IconType } from 'react-icons';
 import type { WeatherMood } from '../types';
 
@@ -16,14 +14,16 @@ export type MoodConfigEntry = {
 };
 
 export const moodConfig: Record<WeatherMood, MoodConfigEntry> = {
-  STORM:     { icon: WiThunderstorm, label: '嵐',       color: '#ffebee', border: '#ef9a9a', text: '#b71c1c' },
-  RAIN:      { icon: WiRain,         label: '雨',       color: '#e3f2fd', border: '#90caf9', text: '#1565c0' },
-  SNOW:      { icon: WiSnow,         label: '雪',       color: '#f3f8ff', border: '#b3d4f5', text: '#37474f' },
-  FOG:       { icon: WiFog,          label: '霧',       color: '#f5f5f5', border: '#bdbdbd', text: '#424242' },
-  CLOUDY:    { icon: WiDayCloudy,    label: 'くもり',   color: '#fff8e1', border: '#ffe082', text: '#5d4037' },
-  WHIRLWIND: { icon: WiStrongWind,   label: 'つむじ風', color: '#fff3e0', border: '#ffcc80', text: '#e65100' },
-  SPROUT:    { icon: FaSeedling,     label: '芽吹き',   color: '#f1f8e9', border: '#aed581', text: '#33691e' },
-  RAINBOW:   { icon: BsRainbow,      label: '虹',       color: '#fce4ec', border: '#f48fb1', text: '#880e4f' },
-  STAR:      { icon: WiNightClear,   label: '星空',     color: '#e8eaf6', border: '#9fa8da', text: '#283593' },
-  SUNNY:     { icon: WiDaySunny,     label: '晴れ',     color: '#e8f5e9', border: '#a5d6a7', text: '#1b5e20' },
+  STORM:     { icon: PiCloudLightningFill, label: '嵐',       color: '#ffebee', border: '#ef9a9a', text: '#b71c1c' },
+  RAIN:      { icon: PiCloudRainFill,      label: '雨',       color: '#e3f2fd', border: '#90caf9', text: '#1565c0' },
+  SNOW:      { icon: PiCloudSnowFill,      label: '雪',       color: '#f3f8ff', border: '#b3d4f5', text: '#37474f' },
+  FOG:       { icon: PiCloudFogFill,       label: '霧',       color: '#f5f5f5', border: '#bdbdbd', text: '#424242' },
+  CLOUDY:    { icon: PiCloudFill,          label: 'くもり',   color: '#fff8e1', border: '#ffe082', text: '#5d4037' },
+  WHIRLWIND: { icon: PiWindFill,           label: 'つむじ風', color: '#fff3e0', border: '#ffcc80', text: '#e65100' },
+  SPROUT:    { icon: PiPlantFill,          label: '芽吹き',   color: '#f1f8e9', border: '#aed581', text: '#33691e' },
+  RAINBOW:   { icon: PiRainbowFill,        label: '虹',       color: '#fce4ec', border: '#f48fb1', text: '#880e4f' },
+  STAR:      { icon: PiMoonStarsFill,      label: '星空',     color: '#e8eaf6', border: '#9fa8da', text: '#283593' },
+  SUNNY:     { icon: PiSunFill,            label: '晴れ',     color: '#e8f5e9', border: '#a5d6a7', text: '#1b5e20' },
 };
+
+

--- a/frontend/src/utils/moodConfig.ts
+++ b/frontend/src/utils/moodConfig.ts
@@ -1,0 +1,29 @@
+import {
+  WiThunderstorm, WiRain, WiSnow, WiFog, WiDayCloudy,
+  WiStrongWind, WiNightClear, WiDaySunny,
+} from 'react-icons/wi';
+import { FaSeedling } from 'react-icons/fa';
+import { BsRainbow } from 'react-icons/bs';
+import type { IconType } from 'react-icons';
+import type { WeatherMood } from '../types';
+
+export type MoodConfigEntry = {
+  icon: IconType;
+  label: string;
+  color: string;
+  border: string;
+  text: string;
+};
+
+export const moodConfig: Record<WeatherMood, MoodConfigEntry> = {
+  STORM:     { icon: WiThunderstorm, label: '嵐',       color: '#ffebee', border: '#ef9a9a', text: '#b71c1c' },
+  RAIN:      { icon: WiRain,         label: '雨',       color: '#e3f2fd', border: '#90caf9', text: '#1565c0' },
+  SNOW:      { icon: WiSnow,         label: '雪',       color: '#f3f8ff', border: '#b3d4f5', text: '#37474f' },
+  FOG:       { icon: WiFog,          label: '霧',       color: '#f5f5f5', border: '#bdbdbd', text: '#424242' },
+  CLOUDY:    { icon: WiDayCloudy,    label: 'くもり',   color: '#fff8e1', border: '#ffe082', text: '#5d4037' },
+  WHIRLWIND: { icon: WiStrongWind,   label: 'つむじ風', color: '#fff3e0', border: '#ffcc80', text: '#e65100' },
+  SPROUT:    { icon: FaSeedling,     label: '芽吹き',   color: '#f1f8e9', border: '#aed581', text: '#33691e' },
+  RAINBOW:   { icon: BsRainbow,      label: '虹',       color: '#fce4ec', border: '#f48fb1', text: '#880e4f' },
+  STAR:      { icon: WiNightClear,   label: '星空',     color: '#e8eaf6', border: '#9fa8da', text: '#283593' },
+  SUNNY:     { icon: WiDaySunny,     label: '晴れ',     color: '#e8f5e9', border: '#a5d6a7', text: '#1b5e20' },
+};


### PR DESCRIPTION
## Summary

- **Comment モデル追加**: 投稿に対してコメントができるようになりました。ありがとうはコメントに紐付く設計に変更。
- **悪質コメント自動検出**: 20語のブロックキーワードリストでマッチしたコメントは自動非表示（`isHidden=true`）。違反ごとに `penaltyCount` が増加し、3回違反で `isRestricted=true`（コメント投稿不可）。
- **Thank モデル変更**: `postId` → `commentId` にキー変更。`@@unique([commentId, fromUserId])` で重複防止。
- **シードデータ更新**: 公開投稿に 64 件のコメント、そのコメントに 25 件のありがとうを生成。

## Changes

### Backend
| ファイル | 変更内容 |
|---|---|
| `prisma/schema.prisma` | `Comment` モデル追加、`Thank.postId` → `commentId`、`User` に `penaltyCount`/`isRestricted` |
| `src/services/comment.service.ts` | 新規: コメント作成（キーワード検出・ペナルティ付与）、コメント一覧取得 |
| `src/services/thank.service.ts` | `postId` → `commentId` に変更、自コメントへのありがとう禁止 |
| `src/routes/comments.ts` | 新規: `POST /posts/:id/comments`、`GET /posts/:id/comments` |
| `src/routes/thanks.ts` | `/posts/:id/thank` → `/comments/:id/thank` |
| `src/types/index.ts` | `CommentResponse` 追加、`UserResponse` に `penaltyCount`/`isRestricted` |

### Frontend
| ファイル | 変更内容 |
|---|---|
| `src/components/CommentSection.tsx` | 新規: コメント一覧・投稿フォーム・ありがとうボタン（他ユーザーのみ）・制限ユーザー警告 |
| `src/components/PostCard.tsx` | thank ロジック削除、末尾に `<CommentSection>` を追加 |
| `src/api/comments.ts` | 新規: `createComment` / `listComments` |
| `src/api/thanks.ts` | エンドポイントを `/comments/:id/thank` に変更 |
| `src/types/index.ts` | `Comment` 型追加、`User` に penalty フィールド |

## Test plan

- [ ] タイムラインで投稿カードの「コメントを見る」をクリック → コメント一覧が表示される
- [ ] コメントを投稿 → 一覧に追加される
- [ ] 他ユーザーのコメントに「💛 ありがとう」を送れる
- [ ] 自分のコメントにはありがとうボタンが表示されない
- [ ] 悪質キーワード（例: `死ね`）を含むコメントを投稿 → 一覧に表示されない
- [ ] 同一ユーザーが3回違反 → コメント投稿フォームが制限メッセージに変わる
- [ ] 同じコメントに同一ユーザーがありがとうを2回送れない

https://claude.ai/code/session_014VQsTEATddUxu472hyknsp

---
_Generated by [Claude Code](https://claude.ai/code/session_014VQsTEATddUxu472hyknsp)_